### PR TITLE
fix: security and infra fixes (#36, #37, #43, #44)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.worktrees
+docs
+app/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================
 # Stage 1 — Download Inter Variable font
 # =============================================================
-FROM alpine AS fonts
+FROM alpine:3 AS fonts
 
 RUN apk add --no-cache curl unzip && \
     curl -fsSL "https://github.com/rsms/inter/releases/download/v4.0/Inter-4.0.zip" \

--- a/app/tests/test-infra.js
+++ b/app/tests/test-infra.js
@@ -1,0 +1,48 @@
+'use strict';
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const DOCKERIGNORE = path.resolve(__dirname, '../../.dockerignore');
+const DOCKERFILE = path.resolve(__dirname, '../../Dockerfile');
+const hasDockerignore = fs.existsSync(DOCKERIGNORE);
+const hasDockerfile = fs.existsSync(DOCKERFILE);
+
+describe('.dockerignore build context (#43)', function() {
+    it('file exists', { skip: !hasDockerignore && 'requires full repo access' }, function() {
+        assert.ok(fs.existsSync(DOCKERIGNORE));
+    });
+
+    it('excludes .git', { skip: !hasDockerignore && 'requires full repo access' }, function() {
+        const c = fs.readFileSync(DOCKERIGNORE, 'utf8');
+        assert.ok(c.includes('.git'), 'must exclude .git');
+    });
+
+    it('excludes .worktrees', { skip: !hasDockerignore && 'requires full repo access' }, function() {
+        const c = fs.readFileSync(DOCKERIGNORE, 'utf8');
+        assert.ok(c.includes('.worktrees'), 'must exclude .worktrees');
+    });
+
+    it('excludes app/tests', { skip: !hasDockerignore && 'requires full repo access' }, function() {
+        const c = fs.readFileSync(DOCKERIGNORE, 'utf8');
+        assert.ok(c.includes('app/tests'), 'must exclude app/tests');
+    });
+
+    it('excludes docs', { skip: !hasDockerignore && 'requires full repo access' }, function() {
+        const c = fs.readFileSync(DOCKERIGNORE, 'utf8');
+        assert.ok(c.includes('docs'), 'must exclude docs');
+    });
+});
+
+describe('Pinned alpine base image (#44)', function() {
+    it('fonts stage uses FROM alpine:3', { skip: !hasDockerfile && 'requires full repo access' }, function() {
+        const c = fs.readFileSync(DOCKERFILE, 'utf8');
+        assert.ok(c.includes('FROM alpine:3'), 'alpine must be pinned to :3');
+    });
+
+    it('does not use bare FROM alpine', { skip: !hasDockerfile && 'requires full repo access' }, function() {
+        const c = fs.readFileSync(DOCKERFILE, 'utf8');
+        assert.ok(!c.match(/FROM alpine\n/) && !c.match(/FROM alpine /), 'must not use bare FROM alpine');
+    });
+});

--- a/app/tests/test-security-hardening.js
+++ b/app/tests/test-security-hardening.js
@@ -21,17 +21,16 @@ describe('ECDH key non-extractable (#36)', function() {
         );
     });
 
-    it('ecdh.js public key importKey does not use extractable: true', function() {
+    it('no ECDH importKey call uses extractable: true', function() {
         assert.ok(
-            !html.includes('rawPublicKey.buffer, { name: "ECDH", namedCurve: "P-521" } , true, []'),
-            'ECDH public key (ecdh.js convertPublicKeyToRaw) must not use extractable: true'
+            !html.includes('namedCurve: "P-521" } , true,'),
+            'No ECDH importKey call may use extractable: true'
         );
     });
 
-    it('ecdh.js public key importKey uses extractable: false', function() {
-        assert.ok(
-            html.includes('rawPublicKey.buffer, { name: "ECDH", namedCurve: "P-521" } , false, []'),
-            'ECDH public key (ecdh.js convertPublicKeyToRaw) must use extractable: false'
-        );
+    it('all ECDH importKey calls use extractable: false', function() {
+        // Verify no remaining true patterns
+        const trueMatches = (html.match(/namedCurve: "P-521" } , true,/g) || []).length;
+        assert.strictEqual(trueMatches, 0, 'No ECDH importKey should use extractable: true');
     });
 });

--- a/app/tests/test-security-hardening.js
+++ b/app/tests/test-security-hardening.js
@@ -1,0 +1,37 @@
+'use strict';
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+
+describe('ECDH key non-extractable (#36)', function() {
+    it('private key importKey does not use extractable: true', function() {
+        assert.ok(
+            !html.includes(', true, ["deriveKey"'),
+            'ECDH private key must not use extractable: true'
+        );
+    });
+
+    it('private key importKey uses extractable: false', function() {
+        assert.ok(
+            html.includes(', false, ["deriveKey"'),
+            'ECDH private key must use extractable: false'
+        );
+    });
+
+    it('ecdh.js public key importKey does not use extractable: true', function() {
+        assert.ok(
+            !html.includes('rawPublicKey.buffer, { name: "ECDH", namedCurve: "P-521" } , true, []'),
+            'ECDH public key (ecdh.js convertPublicKeyToRaw) must not use extractable: true'
+        );
+    });
+
+    it('ecdh.js public key importKey uses extractable: false', function() {
+        assert.ok(
+            html.includes('rawPublicKey.buffer, { name: "ECDH", namedCurve: "P-521" } , false, []'),
+            'ECDH public key (ecdh.js convertPublicKeyToRaw) must use extractable: false'
+        );
+    });
+});

--- a/app/tests/test-security-hardening.js
+++ b/app/tests/test-security-hardening.js
@@ -62,4 +62,18 @@ describe('Filename sanitization (#37)', function() {
             'download_ab must call sanitizeFilename'
         );
     });
+
+    it('sanitizeFilename strips path separators and null bytes', function() {
+        const idx = html.indexOf('function sanitizeFilename(');
+        assert.ok(idx !== -1, 'sanitizeFilename must exist');
+        const body = html.slice(idx, idx + 300);
+        assert.ok(
+            body.includes("replace(/[/\\\\]/g,'')") || body.includes("replace(/[/\\\\]/g, '')"),
+            'must strip slashes'
+        );
+        assert.ok(
+            body.includes("replace(/\\x00/g,'')") || body.includes("replace(/\\x00/g, '')"),
+            'must strip null bytes'
+        );
+    });
 });

--- a/app/tests/test-security-hardening.js
+++ b/app/tests/test-security-hardening.js
@@ -34,3 +34,32 @@ describe('ECDH key non-extractable (#36)', function() {
         assert.strictEqual(trueMatches, 0, 'No ECDH importKey should use extractable: true');
     });
 });
+
+describe('Filename sanitization (#37)', function() {
+    it('sanitizeFilename function is present in built output', function() {
+        assert.ok(
+            html.includes('function sanitizeFilename('),
+            'sanitizeFilename must be defined in built output'
+        );
+    });
+
+    it('sanitizeFilename truncates to 255 characters', function() {
+        const idx = html.indexOf('function sanitizeFilename(');
+        assert.ok(idx !== -1, 'sanitizeFilename must exist');
+        const body = html.slice(idx, idx + 300);
+        assert.ok(
+            body.includes('.slice(0,255)') || body.includes('.slice(0, 255)'),
+            'sanitizeFilename must truncate to 255 chars'
+        );
+    });
+
+    it('download_ab calls sanitizeFilename', function() {
+        const idx = html.indexOf('function download_ab(');
+        assert.ok(idx !== -1, 'download_ab must exist');
+        const body = html.slice(idx, idx + 500);
+        assert.ok(
+            body.includes('sanitizeFilename('),
+            'download_ab must call sanitizeFilename'
+        );
+    });
+});

--- a/src/js/ui/file-import.js
+++ b/src/js/ui/file-import.js
@@ -201,13 +201,16 @@ function handleNewFiles() {
         }
     }
 }
+function sanitizeFilename(file_name) {
+    return file_name.replace(/[/\\]/g, '').replace(/\x00/g, '').slice(0, 255);
+}
 function download_ab(file_name, array_buff) {
     const blob = new Blob([array_buff],{
         type: "application/octet-stream"
     });
     const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);
-    link.download = file_name;
+    link.download = sanitizeFilename(file_name);
     link.click();
     URL.revokeObjectURL(link.href);
 }

--- a/src/js/worker/ecdh.js
+++ b/src/js/worker/ecdh.js
@@ -165,7 +165,7 @@ pubKeyBytes.set(yBytes, 67);
 const pkcs8=buildPKCS8WithPublicKey(privKeyBytes, pubKeyBytes);
 crypto.subtle.importKey( "pkcs8", pkcs8.buffer, {
 name: "ECDH", namedCurve: "P-521" }
-, true, ["deriveKey", "deriveBits"] ).then(function(key) {
+, false, ["deriveKey", "deriveBits"] ).then(function(key) {
 inner_cb({
 success: true, key, pkcs8Buffer: pkcs8.buffer }
 );
@@ -202,7 +202,7 @@ rawPublicKey.set(yBytes, 67);
 try {
 crypto.subtle.importKey( "raw", rawPublicKey.buffer, {
 name: "ECDH", namedCurve: "P-521" }
-, true, [] ).then(function(key){
+, false, [] ).then(function(key){
 inner_cb({
 success: true, key, rawBuffer: rawPublicKey.buffer }
 );

--- a/src/js/worker/encryption.js
+++ b/src/js/worker/encryption.js
@@ -56,7 +56,7 @@ this.importEcdhPub=importEcdhPub;
 function importEcdhPub(pub_buff, cb){
 crypto.subtle.importKey( "raw", pub_buff, {
 name: "ECDH", namedCurve: "P-521" }
-, true, [] ).then(cb).catch(function(e){
+, false, [] ).then(cb).catch(function(e){
 fk_log('error', 'crypto', 'importEcdhPub failed: ' + e.toString());
 cb(null);
 });


### PR DESCRIPTION
## Summary

Four independent fixes from code review of PR #34, bundled together because they're small and share the "security and infra hardening" theme.

- **#36** — ECDH `importKey` calls now use `extractable: false` (both in `src/js/worker/ecdh.js` and `src/js/worker/encryption.js`). No `exportKey` calls exist in the codebase; this is pure defense-in-depth against key exfiltration via Web Crypto.
- **#37** — `download_ab` now passes filenames through a new `sanitizeFilename()` helper that strips path separators (`/`, `\`), null bytes, and truncates to 255 chars.
- **#43** — Added `.dockerignore` excluding `.git/`, `.worktrees/`, `docs/`, `app/tests/` to shrink build context and avoid busting the `js-build` layer cache on unrelated edits.
- **#44** — Pinned `FROM alpine` → `FROM alpine:3` in the fonts stage of the Dockerfile (other stages were already pinned).

## Tests added

- `app/tests/test-security-hardening.js` — asserts ECDH `extractable: false`, `sanitizeFilename` presence and behavior in built output (9 assertions)
- `app/tests/test-infra.js` — asserts `.dockerignore` exists and excludes required paths, asserts Dockerfile pins alpine (7 assertions)

Full suite: **148/148 passing** after `node scripts/build.js`.

## Test plan

- [x] `node scripts/build.js && node --test app/tests/test-*.js` — all 148 pass
- [x] Rebased onto current main (dropped old generated `app/index.html` from pre-refactor commits)
- [ ] CI green (lint-go, lint-config, test-node, test-go, docker-build)
- [ ] Verify Dockerfile still builds with pinned `alpine:3`

Closes #36
Closes #37
Closes #43
Closes #44