### PR TITLE
refactor: rewrite get_query_strings with URLSearchParams

### DIFF
--- a/app/tests/test-query-strings.js
+++ b/app/tests/test-query-strings.js
@@ -1,0 +1,39 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const utilsSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'js', 'lib', 'utils.js'),
+    'utf8'
+);
+
+function loadGetQueryStrings(search) {
+    const sandbox = {
+        window: { location: { search } },
+    };
+    const fn = new Function('window', utilsSrc + '; return get_query_strings;');
+    return fn(sandbox.window);
+}
+
+describe('get_query_strings', () => {
+    const cases = [
+        ['?pub=abc123',      { pub: 'abc123' }],
+        ['?debug=true',      { debug: true }],
+        ['?foo=42',          { foo: 42 }],
+        ['?bar=null',        { bar: null }],
+        ['?x=false',         { x: false }],
+        ['?flag',            { flag: true }],
+        ['?flag=',           { flag: true }],
+        ['?a=1&b=hello',     { a: 1, b: 'hello' }],
+        ['?n=42abc',         { n: '42abc' }],
+        ['?f=3.14',          { f: '3.14' }],
+        ['',                 {}],
+    ];
+    for (const [search, expected] of cases) {
+        it(`parses "${search}"`, () => {
+            const getQs = loadGetQueryStrings(search);
+            assert.deepStrictEqual(getQs(), expected);
+        });
+    }
+});

--- a/src/js/app/init.js
+++ b/src/js/app/init.js
@@ -51,7 +51,7 @@ function initVersionChecks() {
     setVersionNumber();
 }
 function initQueryChecks() {
-    var temp_qs = get_query_strings(false);
+    var temp_qs = get_query_strings();
     if (checkForProperty(temp_qs.pub))
         confirmAndAttachPub(temp_qs.pub, function(ret) {});
 }

--- a/src/js/lib/utils.js
+++ b/src/js/lib/utils.js
@@ -7,45 +7,15 @@ function sanitizeFilename(file_name) {
 function getRandomInclusive(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
-function get_query_strings(return_as_array=false) {
-    var results = {};
-    if (window.location.search != "") {
-        var param;
-        var searched = window.location.search;
-        searched = searched.substring(1);
-        searched = searched.split("&");
-        if (return_as_array)
-            return searched;
-        else {
-            for (var i = 0; i < searched.length; i++)
-                parsePair(results, searched);
-        }
+function get_query_strings() {
+    const results = {};
+    for (const [key, raw] of new URLSearchParams(window.location.search)) {
+        if (raw === '')      { results[key] = true;  continue; }
+        if (raw === 'null')  { results[key] = null;  continue; }
+        if (raw === 'true')  { results[key] = true;  continue; }
+        if (raw === 'false') { results[key] = false; continue; }
+        const n = parseInt(raw, 10);
+        results[key] = (!isNaN(n) && String(n).length === raw.length) ? n : raw;
     }
     return results;
-    function parsePair(results, pair) {
-        var value;
-        pair = pair[i].split("=");
-        if ((typeof pair[1] === "undefined"))
-            value = true;
-        else {
-            switch (pair[1]) {
-            case "null":
-                value = null;
-                break;
-            case "false":
-                value = false;
-                break;
-            case "true":
-                value = true;
-                break;
-            default:
-                var temp = parseInt(pair[1]);
-                if (isNaN(temp))
-                    value = pair[1];
-                else
-                    value = (temp.toString().length == pair[1].length) ? temp : pair[1];
-            }
-        }
-        results[pair[0]] = value;
-    }
 }


### PR DESCRIPTION
## Summary
- Replace hand-rolled `get_query_strings` parser (broken closure, dead `return_as_array` branch) with a 9-line `URLSearchParams`-based implementation preserving all coercion semantics (empty/null/true/false/integer).
- Add 11 table-driven unit tests covering every coercion branch, including the `?flag=` edge case the old code got wrong.
- Drop the dead `false` argument from the sole caller in `init.js`.

## Test plan
- [x] `docker run --rm -v $(pwd):/work -w /work node:22-alpine sh -c "node scripts/build.js && node --test app/tests/test-*.js"` — 177/177 passing
- [x] No `return_as_array` references remain in `src/`
- [x] All callers use zero-arg `get_query_strings()`
- [x] `?flag=` now correctly returns `{ flag: true }` (previously `{ flag: '' }`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)