### PR TITLE
refactor: collapse secureOverwriteBuffer to pattern-fill only

### DIFF
--- a/app/tests/test-secure-overwrite.js
+++ b/app/tests/test-secure-overwrite.js
@@ -1,0 +1,51 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'js', 'lib', 'crypto-storage.js'),
+    'utf8'
+);
+
+function loadSecureOverwrite() {
+    const fn = new Function(src + '; return secureOverwriteBuffer;');
+    return fn();
+}
+
+describe('secureOverwriteBuffer', () => {
+    it('fills buffer with FF-00-FF-00 pattern', (t, done) => {
+        const secureOverwriteBuffer = loadSecureOverwrite();
+        secureOverwriteBuffer(16, (buf) => {
+            const view = new Uint8Array(buf);
+            assert.strictEqual(view.length, 16);
+            assert.deepStrictEqual(
+                Array.from(view),
+                [0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+                 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00]
+            );
+            done();
+        });
+    });
+
+    it('handles zero length', (t, done) => {
+        const secureOverwriteBuffer = loadSecureOverwrite();
+        secureOverwriteBuffer(0, (buf) => {
+            assert.strictEqual(buf.byteLength, 0);
+            done();
+        });
+    });
+
+    it('handles length not divisible by 4', (t, done) => {
+        const secureOverwriteBuffer = loadSecureOverwrite();
+        secureOverwriteBuffer(5, (buf) => {
+            const view = new Uint8Array(buf);
+            assert.strictEqual(view.length, 5);
+            assert.deepStrictEqual(
+                Array.from(view),
+                [0xFF, 0x00, 0xFF, 0x00, 0xFF]
+            );
+            done();
+        });
+    });
+});

--- a/src/js/lib/crypto-storage.js
+++ b/src/js/lib/crypto-storage.js
@@ -96,32 +96,13 @@ function database(db_name, stores, version_number, cb) {
     }
 }
 
-function secureOverwriteBuffer(dataLength, useRandom=true, callback) {
-    if (!useRandom) {
-        const pattern = new Uint8Array([0xFF, 0x00, 0xFF, 0x00]);
-        const overwriteData = new Uint8Array(dataLength);
-        for (let i = 0; i < dataLength; i++) {
-            overwriteData[i] = pattern[i % pattern.length];
-        }
-        callback(overwriteData.buffer);
-    } else {
-        const chunkSize = 65536;
-        const overwriteData = new Uint8Array(dataLength);
-        let offset = 0;
-        function fillNextChunk() {
-            if (offset >= dataLength) {
-                callback(overwriteData.buffer);
-                return;
-            }
-            const remainingBytes = Math.min(chunkSize, dataLength - offset);
-            const chunk = new Uint8Array(remainingBytes);
-            self.crypto.getRandomValues(chunk);
-            overwriteData.set(chunk, offset);
-            offset += remainingBytes;
-            setTimeout(fillNextChunk, 0);
-        }
-        fillNextChunk();
+function secureOverwriteBuffer(dataLength, callback) {
+    const pattern = new Uint8Array([0xFF, 0x00, 0xFF, 0x00]);
+    const overwriteData = new Uint8Array(dataLength);
+    for (let i = 0; i < dataLength; i++) {
+        overwriteData[i] = pattern[i % pattern.length];
     }
+    callback(overwriteData.buffer);
 }
 function securelyDeleteFromStore(dbHandler, storeNames, callback) {
     if (!Array.isArray(storeNames)) {
@@ -152,7 +133,7 @@ function securelyDeleteFromStore(dbHandler, storeNames, callback) {
                     const recordToOverwrite = event.target.result;
                     if (recordToOverwrite && recordToOverwrite.data) {
                         const dataLength = recordToOverwrite.data.byteLength;
-                        secureOverwriteBuffer(dataLength, false, function(overwriteData) {
+                        secureOverwriteBuffer(dataLength, function(overwriteData) {
                             recordToOverwrite.data = overwriteData;
                             const putRequest = writeableStore.put(recordToOverwrite);
                             putRequest.onsuccess = function() {


### PR DESCRIPTION
## Summary
- Delete the dead `useRandom=true` async random-fill branch from `secureOverwriteBuffer` in `crypto-storage.js` — the sole caller already passed `false`.
- Collapse the function from 27 lines (3-arg with async cooperative yield) to 7 lines (2-arg synchronous pattern fill).
- Add 3 unit tests (16-byte aligned, zero-length, non-divisible-by-4) verifying the `FF 00 FF 00` pattern output.

## Test plan
- [x] `docker run --rm -v $(pwd):/work -w /work node:22-alpine sh -c "node scripts/build.js && node --test app/tests/test-*.js"` — 169/169 passing
- [x] No `useRandom` references remain in `src/`
- [x] Both `secureOverwriteBuffer` references (definition + caller) use 2-arg form
- [x] Security-hardening tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)