### PR TITLE
feat(share): Phase 4 — Share Center + per-file share/save/export

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -40,7 +40,7 @@ func buildHandler(distFS fs.FS, indexContent string) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		w.Header().Set("Permissions-Policy", "camera=(self), microphone=(), geolocation=()")
 		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -84,7 +84,7 @@ func TestSecurityHeaders(t *testing.T) {
 		"X-Frame-Options":           "DENY",
 		"X-Content-Type-Options":    "nosniff",
 		"Referrer-Policy":           "strict-origin-when-cross-origin",
-		"Permissions-Policy":        "camera=(), microphone=(), geolocation=()",
+		"Permissions-Policy":        "camera=(self), microphone=(), geolocation=()",
 		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
 	}
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/icons": "^6.3.2",
         "antd": "^6.5.0",
+        "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0"
@@ -20,6 +21,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.20.1",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^18.3.31",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^6.0.3",
@@ -4406,6 +4408,16 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
@@ -4965,7 +4977,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5348,6 +5359,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001803",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
@@ -5429,6 +5449,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5437,6 +5468,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -5635,6 +5684,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -5733,6 +5791,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -5777,6 +5841,12 @@
       "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -6124,6 +6194,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6250,6 +6333,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6762,6 +6854,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -7488,6 +7589,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lodash.debounce": {
@@ -8315,6 +8428,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8358,6 +8507,15 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -8419,6 +8577,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8513,6 +8680,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -8722,6 +8906,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8731,6 +8924,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -8941,6 +9140,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9288,6 +9493,20 @@
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -9403,6 +9622,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-comments": {
@@ -10363,6 +10594,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -10622,6 +10859,35 @@
         "workbox-core": "7.4.1"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -10639,12 +10905,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,8 @@
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "zxing-wasm": "^3.1.0"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -4351,6 +4352,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -9703,6 +9710,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -10961,6 +10980,34 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.0.tgz",
+      "integrity": "sha512-5+3V1wPRx4gvbeLH2jB7n2cKrYJ1q4i3QgjnBUtrDPeqxJSi6BdzKJg4y6aF6bgW8zfntnYJyrkqFMevDhL2NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.7.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ant-design/icons": "^6.3.2",
     "antd": "^6.5.0",
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0"
@@ -24,6 +25,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.20.1",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "zxing-wasm": "^3.1.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -24,6 +24,7 @@ vi.mock('./files/db', () => ({
   saveJob: vi.fn().mockResolvedValue(undefined),
   getJob: vi.fn().mockResolvedValue(null),
   clearJobs: vi.fn().mockResolvedValue(undefined),
+  clearRecipients: vi.fn().mockResolvedValue(undefined),
   requestPersistence: vi.fn().mockResolvedValue(true),
 }));
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -26,6 +26,8 @@ vi.mock('./files/db', () => ({
   clearJobs: vi.fn().mockResolvedValue(undefined),
   clearRecipients: vi.fn().mockResolvedValue(undefined),
   requestPersistence: vi.fn().mockResolvedValue(true),
+  // resolveInboundShare (inbound.tsx) looks up saved recipients by pubHex.
+  listRecipients: vi.fn().mockResolvedValue([]),
 }));
 
 const call = vi.mocked(rpc.call);
@@ -63,28 +65,19 @@ describe('App', () => {
     await waitFor(() => expect(vi.mocked(clearJobs)).toHaveBeenCalled());
   });
 
-  it('attaches a valid ?pub= key via set_shared_pub and shows the parity banner', async () => {
+  it('shows the inbound share banner for a valid ?pub= key', async () => {
     window.history.replaceState({}, '', `/?pub=${VALID_PUB}`);
     call.mockImplementation(async (t: string) => (t === 'set_shared_pub' ? true : null));
     renderApp();
 
-    await waitFor(() =>
-      expect(call).toHaveBeenCalledWith(
-        'set_shared_pub',
-        { pub_buff: expect.any(ArrayBuffer) },
-        [expect.any(ArrayBuffer)],
-      ),
-    );
-    const banner = await screen.findByRole('alert');
-    expect(banner).toHaveTextContent(/share key attached/i);
-    expect(banner).toHaveTextContent(/04aa…aaaa/i);
+    expect(await screen.findByText(/sharing to 04aa…aaaa/i)).toBeInTheDocument();
   });
 
   it('ignores an invalid ?pub= value', async () => {
     window.history.replaceState({}, '', '/?pub=deadbeef');
     renderApp();
     await waitFor(() => expect(vi.mocked(clearJobs)).toHaveBeenCalled());
-    expect(call.mock.calls.some(([t]) => t === 'set_shared_pub')).toBe(false);
+    expect(screen.queryByText(/sharing to/i)).toBeNull();
   });
 
   it('unlocking swaps onboarding for the drop zone; reset returns to onboarding', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,12 @@ import { Alert, Layout } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { rpc } from './crypto/client';
 import { hexToArrayBuffer } from './crypto/buffer';
-import { clearJobs as clearJobCache, requestPersistence, saveJob } from './files/db';
+import {
+  clearJobs as clearJobCache,
+  clearRecipients,
+  requestPersistence,
+  saveJob,
+} from './files/db';
 import { jobStatusLabel, processFiles, type FileJob } from './files/ops';
 import { StatusAnnouncer } from './a11y/StatusAnnouncer';
 import { AppHeader } from './ui/AppHeader';
@@ -83,9 +88,9 @@ export default function App() {
   );
 
   const handleReset = useCallback(async () => {
-    // Nuclear option (design §5.4): wipe session + file cache, replay onboarding.
-    // Phase 4 adds the saved-recipients wipe here.
-    await clearJobCache();
+    // Nuclear option (design §5.4): wipe session + file cache + saved recipients,
+    // replay onboarding. Lock (header onLock) intentionally does not touch recipients.
+    await Promise.all([clearJobCache(), clearRecipients()]);
     await lock();
     setJobs([]);
     setAttachedPub(null);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,5 @@
-import { Alert, Layout } from 'antd';
+import { App as AntApp, Layout } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { rpc } from './crypto/client';
-import { hexToArrayBuffer } from './crypto/buffer';
 import {
   clearJobs as clearJobCache,
   clearRecipients,
@@ -18,8 +16,12 @@ import { InfoModal } from './ui/InfoModal';
 import { Onboarding } from './ui/Onboarding';
 import { UpdatePrompt } from './pwa/UpdatePrompt';
 import { useSession } from './state/session';
-
-const PUB_RE = /^04[0-9a-fA-F]{264}$/;
+import {
+  InboundShareBanner,
+  InboundShareContext,
+  resolveInboundShare,
+  type InboundShare,
+} from './share/inbound';
 
 const DOC_TITLES: Record<DocKey, string> = {
   howItWorks: 'How FileKey Works',
@@ -32,11 +34,12 @@ function appVersion(): string {
 }
 
 export default function App() {
+  const { message } = AntApp.useApp();
   const { locked, unlock, lock } = useSession();
   const [ready, setReady] = useState(false);
   const [jobs, setJobs] = useState<FileJob[]>([]);
   const [openDoc, setOpenDoc] = useState<DocKey | null>(null);
-  const [attachedPub, setAttachedPub] = useState<string | null>(null);
+  const [inbound, setInbound] = useState<InboundShare | null>(null);
 
   // First successful unlock completes onboarding for this session.
   useEffect(() => {
@@ -53,16 +56,17 @@ export default function App() {
     });
   }, []);
 
-  // ?pub= parity (design §2.2/§9): validate, attach, minimal notice. Full banner
-  // UX (saved-recipient matching, save-as-recipient) is Phase 4.
+  // Inbound ?pub= deep link (design §8.3/§14): validate, resolve saved-recipient
+  // name, offer save-as-recipient. Leaves the key attached in the worker.
   useEffect(() => {
-    const pub = new URLSearchParams(window.location.search).get('pub');
-    if (!pub || !PUB_RE.test(pub)) return;
-    const pub_buff = hexToArrayBuffer(pub);
-    rpc
-      .call('set_shared_pub', { pub_buff }, [pub_buff])
-      .then(() => setAttachedPub(pub))
-      .catch(() => setAttachedPub(null));
+    resolveInboundShare(location.search).then((result) => {
+      if (result === 'invalid') {
+        message.error('Invalid share link');
+      } else if (result !== null) {
+        setInbound(result);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onJob = useCallback((job: FileJob) => {
@@ -93,63 +97,60 @@ export default function App() {
     await Promise.all([clearJobCache(), clearRecipients()]);
     await lock();
     setJobs([]);
-    setAttachedPub(null);
+    setInbound(null);
     setReady(false);
   }, [lock]);
 
   const version = useMemo(appVersion, []);
 
   return (
-    <Layout style={{ minHeight: '100dvh' }}>
-      <UpdatePrompt />
-      <StatusAnnouncer
-        jobs={jobs.map((j) => ({ id: j.id, name: j.name, status: jobStatusLabel(j) }))}
-      />
-      <AppHeader
-        locked={locked}
-        onLock={() => void lock()}
-        onReset={() => void handleReset()}
-        onOpenDoc={setOpenDoc}
-        version={version}
-      />
-      {attachedPub && (
-        <Alert
-          type="info"
-          showIcon
-          closable
-          role="alert"
-          style={{ margin: '0 16px' }}
-          message={`Share key attached: ${attachedPub.slice(0, 4)}…${attachedPub.slice(-4)}`}
-          description="This recipient key is set for this session."
-          onClose={() => setAttachedPub(null)}
+    <InboundShareContext.Provider value={inbound}>
+      {inbound !== null && (
+        <InboundShareBanner
+          share={inbound}
+          onSaved={(name) => setInbound({ ...inbound, recipientName: name })}
+          onDismiss={() => setInbound(null)}
         />
       )}
-      <Layout.Content
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 16,
-          padding: 16,
-          paddingBottom: 'max(16px, env(safe-area-inset-bottom))',
-          paddingLeft: 'max(16px, env(safe-area-inset-left))',
-          paddingRight: 'max(16px, env(safe-area-inset-right))',
-        }}
-      >
-        {!ready ? (
-          <Onboarding onOpenDoc={setOpenDoc} />
-        ) : (
-          <>
-            <FileList jobs={jobs} />
-            <DropZone onFiles={(files) => void handleFiles(files)} />
-          </>
-        )}
-      </Layout.Content>
-      <InfoModal
-        title={openDoc ? DOC_TITLES[openDoc] : ''}
-        markdown={openDoc ? DOCS[openDoc] : ''}
-        open={openDoc !== null}
-        onClose={() => setOpenDoc(null)}
-      />
-    </Layout>
+      <Layout style={{ minHeight: '100dvh' }}>
+        <UpdatePrompt />
+        <StatusAnnouncer
+          jobs={jobs.map((j) => ({ id: j.id, name: j.name, status: jobStatusLabel(j) }))}
+        />
+        <AppHeader
+          locked={locked}
+          onLock={() => void lock()}
+          onReset={() => void handleReset()}
+          onOpenDoc={setOpenDoc}
+          version={version}
+        />
+        <Layout.Content
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+            padding: 16,
+            paddingBottom: 'max(16px, env(safe-area-inset-bottom))',
+            paddingLeft: 'max(16px, env(safe-area-inset-left))',
+            paddingRight: 'max(16px, env(safe-area-inset-right))',
+          }}
+        >
+          {!ready ? (
+            <Onboarding onOpenDoc={setOpenDoc} />
+          ) : (
+            <>
+              <FileList jobs={jobs} />
+              <DropZone onFiles={(files) => void handleFiles(files)} />
+            </>
+          )}
+        </Layout.Content>
+        <InfoModal
+          title={openDoc ? DOC_TITLES[openDoc] : ''}
+          markdown={openDoc ? DOCS[openDoc] : ''}
+          open={openDoc !== null}
+          onClose={() => setOpenDoc(null)}
+        />
+      </Layout>
+    </InboundShareContext.Provider>
   );
 }

--- a/web/src/files/db.recipients.test.ts
+++ b/web/src/files/db.recipients.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+
+type DbModule = typeof import('./db');
+let db: DbModule;
+
+beforeEach(async () => {
+  vi.resetModules(); // drop any cached IDB connection inside db.ts
+  globalThis.indexedDB = new IDBFactory();
+  db = await import('./db');
+});
+
+describe('recipients store', () => {
+  it('addRecipient returns a complete Recipient with normalized hex', async () => {
+    const before = Date.now();
+    const r = await db.addRecipient('Alice', VALID_HEX.toUpperCase());
+    expect(r.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(r.name).toBe('Alice');
+    expect(r.pubHex).toBe(VALID_HEX.toLowerCase());
+    expect(r.createdTs).toBeGreaterThanOrEqual(before);
+  });
+
+  it('listRecipients returns saved recipients sorted by name', async () => {
+    await db.addRecipient('Zoe', VALID_HEX);
+    await db.addRecipient('Alice', VALID_HEX);
+    const names = (await db.listRecipients()).map((r) => r.name);
+    expect(names).toEqual(['Alice', 'Zoe']);
+  });
+
+  it('renameRecipient updates the name and keeps other fields', async () => {
+    const r = await db.addRecipient('Alice', VALID_HEX);
+    await db.renameRecipient(r.id, 'Alice Work');
+    const [got] = await db.listRecipients();
+    expect(got.name).toBe('Alice Work');
+    expect(got.pubHex).toBe(r.pubHex);
+    expect(got.createdTs).toBe(r.createdTs);
+  });
+
+  it('renameRecipient rejects for an unknown id', async () => {
+    await expect(db.renameRecipient('nope', 'x')).rejects.toThrow(/not found/);
+  });
+
+  it('deleteRecipient removes exactly one recipient', async () => {
+    const a = await db.addRecipient('Alice', VALID_HEX);
+    await db.addRecipient('Bob', VALID_HEX);
+    await db.deleteRecipient(a.id);
+    const names = (await db.listRecipients()).map((r) => r.name);
+    expect(names).toEqual(['Bob']);
+  });
+
+  it('clearRecipients empties the store (Reset semantics)', async () => {
+    await db.addRecipient('Alice', VALID_HEX);
+    await db.clearRecipients();
+    expect(await db.listRecipients()).toEqual([]);
+  });
+});

--- a/web/src/files/db.ts
+++ b/web/src/files/db.ts
@@ -1,11 +1,12 @@
 import type { FileJob } from './ops';
 
 const DB_NAME = 'filekey_temp_db';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const STORE = 'jobs';
 // v1 store from the pre-antd app — dropped on upgrade so existing users' stale
 // session caches are cleaned the first time the new app loads.
 const OLD_STORE = 'data_store';
+const RECIPIENTS_STORE = 'recipients';
 
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -14,21 +15,29 @@ function openDb(): Promise<IDBDatabase> {
       const db = req.result;
       if (db.objectStoreNames.contains(OLD_STORE)) db.deleteObjectStore(OLD_STORE);
       if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'id' });
+      if (!db.objectStoreNames.contains(RECIPIENTS_STORE)) {
+        db.createObjectStore(RECIPIENTS_STORE, { keyPath: 'id' });
+      }
     };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
   });
 }
 
+// Single source of truth for open → transaction → close. Every store access
+// (jobs and recipients) routes through here so the connection is always closed
+// in the finally block — a leaked connection with no onversionchange handler
+// could otherwise block a future onupgradeneeded (DB_VERSION bump).
 async function withStore<T>(
+  storeName: string,
   mode: IDBTransactionMode,
   run: (store: IDBObjectStore) => IDBRequest,
 ): Promise<T> {
   const db = await openDb();
   try {
     return await new Promise<T>((resolve, reject) => {
-      const t = db.transaction(STORE, mode);
-      const req = run(t.objectStore(STORE));
+      const t = db.transaction(storeName, mode);
+      const req = run(t.objectStore(storeName));
       req.onsuccess = () => resolve(req.result as T);
       req.onerror = () => reject(req.error);
     });
@@ -38,16 +47,16 @@ async function withStore<T>(
 }
 
 export async function saveJob(job: FileJob): Promise<void> {
-  await withStore('readwrite', (s) => s.put(job));
+  await withStore(STORE, 'readwrite', (s) => s.put(job));
 }
 
 export async function getJob(id: string): Promise<FileJob | null> {
-  const res = await withStore<FileJob | undefined>('readonly', (s) => s.get(id));
+  const res = await withStore<FileJob | undefined>(STORE, 'readonly', (s) => s.get(id));
   return res ?? null;
 }
 
 export async function clearJobs(): Promise<void> {
-  await withStore('readwrite', (s) => s.clear());
+  await withStore(STORE, 'readwrite', (s) => s.clear());
 }
 
 // Parity with the old app's persistent-storage request. Best-effort: browsers may
@@ -60,4 +69,48 @@ export async function requestPersistence(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// --- Recipients (Phase 4, design §8.1) -------------------------------------
+// Stored only on this device. Lock keeps recipients; Reset wipes them.
+
+export type Recipient = {
+  id: string;
+  name: string;
+  pubHex: string; // normalized lowercase 266-hex
+  createdTs: number;
+};
+
+export async function listRecipients(): Promise<Recipient[]> {
+  const all = await withStore<Recipient[]>(RECIPIENTS_STORE, 'readonly', (s) => s.getAll());
+  return all.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function addRecipient(name: string, pubHex: string): Promise<Recipient> {
+  const recipient: Recipient = {
+    id: crypto.randomUUID(),
+    name,
+    pubHex: pubHex.toLowerCase(),
+    createdTs: Date.now(),
+  };
+  await withStore(RECIPIENTS_STORE, 'readwrite', (s) => s.add(recipient));
+  return recipient;
+}
+
+export async function renameRecipient(id: string, name: string): Promise<void> {
+  const existing = await withStore<Recipient | undefined>(
+    RECIPIENTS_STORE,
+    'readonly',
+    (s) => s.get(id),
+  );
+  if (existing === undefined) throw new Error(`recipient not found: ${id}`);
+  await withStore(RECIPIENTS_STORE, 'readwrite', (s) => s.put({ ...existing, name }));
+}
+
+export async function deleteRecipient(id: string): Promise<void> {
+  await withStore(RECIPIENTS_STORE, 'readwrite', (s) => s.delete(id));
+}
+
+export async function clearRecipients(): Promise<void> {
+  await withStore(RECIPIENTS_STORE, 'readwrite', (s) => s.clear());
 }

--- a/web/src/files/save.test.ts
+++ b/web/src/files/save.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { sanitizeFilename, saveJob } from './save';
+import { downloadBlob, sanitizeFilename, saveJob } from './save';
 import type { FileJob } from './ops';
 
 describe('sanitizeFilename', () => {
@@ -32,6 +32,30 @@ describe('saveJob', () => {
     saveJob(job);
 
     expect(createUrl).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(revokeUrl).toHaveBeenCalledWith('blob:fake');
+    createUrl.mockRestore();
+    revokeUrl.mockRestore();
+    click.mockRestore();
+  });
+});
+
+describe('downloadBlob', () => {
+  it('sanitizes the filename before setting a.download (defense-in-depth for attacker-influenceable names)', () => {
+    const createUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake');
+    const revokeUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      expect(this.download).toBe('abcd.txt');
+      expect(this.href).toContain('blob:fake');
+    });
+
+    const blob = new Blob([new Uint8Array([1])], { type: 'application/octet-stream' });
+    downloadBlob(blob, 'a/b\\c\x00d.txt');
+
+    expect(createUrl).toHaveBeenCalledTimes(1);
+    expect(createUrl).toHaveBeenCalledWith(blob);
     expect(click).toHaveBeenCalledTimes(1);
     expect(revokeUrl).toHaveBeenCalledWith('blob:fake');
     createUrl.mockRestore();

--- a/web/src/files/save.ts
+++ b/web/src/files/save.ts
@@ -6,13 +6,21 @@ export function sanitizeFilename(name: string): string {
 }
 
 // <a download> save path (design §8.2 note: Web Share for files is Phase 4).
-export function saveJob(job: FileJob): void {
-  if (!job.data || !job.outName) return;
-  const blob = new Blob([job.data], { type: 'application/octet-stream' });
+// Single source for the <a download> dance — every download path (Save, Share
+// Save) routes through here so the download attribute is always sanitized
+// (defense-in-depth: filenames can be attacker-influenceable, e.g. a name
+// embedded in a decrypted .filekey).
+export function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = sanitizeFilename(job.outName);
+  a.download = sanitizeFilename(filename);
   a.click();
   URL.revokeObjectURL(url);
+}
+
+export function saveJob(job: FileJob): void {
+  if (!job.data || !job.outName) return;
+  const blob = new Blob([job.data], { type: 'application/octet-stream' });
+  downloadBlob(blob, job.outName);
 }

--- a/web/src/share/QrScanner.test.tsx
+++ b/web/src/share/QrScanner.test.tsx
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { hasCamera, QrScanner } from './QrScanner';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+const DEEP_LINK = `https://filekey.example/?pub=${VALID_HEX.toUpperCase()}`;
+
+function fakeStream() {
+  const stop = vi.fn();
+  return { stream: { getTracks: () => [{ stop }] } as unknown as MediaStream, stop };
+}
+
+function installMediaDevices(overrides: Partial<MediaDevices>) {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: overrides,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as unknown as Record<string, unknown>).BarcodeDetector;
+});
+
+describe('hasCamera', () => {
+  it('is true when a videoinput device exists', async () => {
+    installMediaDevices({
+      enumerateDevices: vi.fn().mockResolvedValue([
+        { kind: 'audioinput' },
+        { kind: 'videoinput' },
+      ]),
+    } as unknown as MediaDevices);
+    expect(await hasCamera()).toBe(true);
+  });
+
+  it('is false without videoinput, without mediaDevices, or on failure', async () => {
+    installMediaDevices({
+      enumerateDevices: vi.fn().mockResolvedValue([{ kind: 'audioinput' }]),
+    } as unknown as MediaDevices);
+    expect(await hasCamera()).toBe(false);
+
+    Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true });
+    expect(await hasCamera()).toBe(false);
+
+    installMediaDevices({
+      enumerateDevices: vi.fn().mockRejectedValue(new Error('nope')),
+    } as unknown as MediaDevices);
+    expect(await hasCamera()).toBe(false);
+  });
+});
+
+describe('QrScanner', () => {
+  let getUserMedia: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const { stream } = fakeStream();
+    getUserMedia = vi.fn().mockResolvedValue(stream);
+    installMediaDevices({ getUserMedia } as unknown as MediaDevices);
+    // jsdom has no HTMLMediaElement.play
+    Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+      value: vi.fn().mockResolvedValue(undefined),
+      configurable: true,
+    });
+  });
+
+  it('uses BarcodeDetector when native and reports the parsed hex', async () => {
+    class FakeBarcodeDetector {
+      static lastOpts: unknown;
+      constructor(opts: unknown) {
+        FakeBarcodeDetector.lastOpts = opts;
+      }
+      async detect() {
+        return [{ rawValue: DEEP_LINK }];
+      }
+    }
+    (window as unknown as Record<string, unknown>).BarcodeDetector = FakeBarcodeDetector;
+
+    const onScan = vi.fn();
+    render(<QrScanner onScan={onScan} onClose={vi.fn()} />);
+
+    expect(getUserMedia).toHaveBeenCalledWith({ video: { facingMode: 'environment' } });
+    await waitFor(() => expect(onScan).toHaveBeenCalledWith(VALID_HEX.toLowerCase()), {
+      timeout: 2000,
+    });
+    expect(FakeBarcodeDetector.lastOpts).toEqual({ formats: ['qr_code'] });
+  });
+
+  it('ignores scanned text that is not a share key or link', async () => {
+    class NoiseDetector {
+      async detect() {
+        return [{ rawValue: 'https://example.com/not-a-key' }];
+      }
+    }
+    (window as unknown as Record<string, unknown>).BarcodeDetector = NoiseDetector;
+
+    const onScan = vi.fn();
+    render(<QrScanner onScan={onScan} onClose={vi.fn()} />);
+    await new Promise((r) => setTimeout(r, 700)); // > 2 poll ticks
+    expect(onScan).not.toHaveBeenCalled();
+  });
+
+  it('shows the paste-field hint when camera permission is denied', async () => {
+    getUserMedia.mockRejectedValue(new DOMException('denied', 'NotAllowedError'));
+    render(<QrScanner onScan={vi.fn()} onClose={vi.fn()} />);
+    expect(await screen.findByText('Camera unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText(/paste the share link or raw key into the field above/i),
+    ).toBeInTheDocument();
+  });
+
+  it('stops camera tracks on unmount', async () => {
+    const { stream, stop } = fakeStream();
+    getUserMedia.mockResolvedValue(stream);
+    class IdleDetector {
+      async detect() {
+        return [];
+      }
+    }
+    (window as unknown as Record<string, unknown>).BarcodeDetector = IdleDetector;
+
+    const { unmount } = render(<QrScanner onScan={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(stop).toHaveBeenCalled());
+  });
+
+  it('falls back to zxing-wasm when BarcodeDetector is absent and reports the parsed hex', async () => {
+    vi.doMock('zxing-wasm/reader', () => ({
+      prepareZXingModule: vi.fn(),
+      readBarcodes: vi.fn().mockResolvedValue([{ text: DEEP_LINK }]),
+    }));
+    vi.doMock('zxing-wasm/reader/zxing_reader.wasm?url', () => ({ default: 'test.wasm' }));
+
+    // No BarcodeDetector on window -> makeDetector() takes the zxing-wasm branch.
+    Object.defineProperty(HTMLVideoElement.prototype, 'videoWidth', {
+      value: 320,
+      configurable: true,
+    });
+    Object.defineProperty(HTMLVideoElement.prototype, 'videoHeight', {
+      value: 240,
+      configurable: true,
+    });
+    const getImageData = vi.fn().mockReturnValue({} as ImageData);
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage,
+      getImageData,
+    } as unknown as CanvasRenderingContext2D);
+
+    const onScan = vi.fn();
+    render(<QrScanner onScan={onScan} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(onScan).toHaveBeenCalledWith(VALID_HEX.toLowerCase()), {
+      timeout: 2000,
+    });
+  });
+
+  it('does not start the scan loop when unmounted while the zxing-wasm detector is still loading', async () => {
+    // Force a fresh dynamic import so this test's deferred mock is used, not the
+    // instant-resolving mock cached by the fallback test above.
+    vi.resetModules();
+    let releaseImport: () => void = () => {};
+    const importGate = new Promise<void>((resolve) => {
+      releaseImport = resolve;
+    });
+    let factoryInvoked = false;
+    const readBarcodes = vi.fn().mockResolvedValue([{ text: DEEP_LINK }]);
+    vi.doMock('zxing-wasm/reader', async () => {
+      factoryInvoked = true;
+      await importGate; // detector load stays pending until we release it
+      return { prepareZXingModule: vi.fn(), readBarcodes };
+    });
+    vi.doMock('zxing-wasm/reader/zxing_reader.wasm?url', () => ({ default: 'test.wasm' }));
+
+    // The component's only setInterval is the 300ms poll — a precise signal for
+    // "a scan loop was started". The bug creates it AFTER cleanup ran.
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const onScan = vi.fn();
+    const { unmount } = render(<QrScanner onScan={onScan} onClose={vi.fn()} />);
+
+    // makeDetector() has begun the dynamic import and is now awaiting it.
+    await waitFor(() => expect(factoryInvoked).toBe(true));
+
+    // Unmount while the import is still pending: cleanup runs, timer is still null.
+    unmount();
+
+    // Resolve the import; the resumed async effect must short-circuit on `cancelled`.
+    releaseImport();
+    await importGate;
+    await new Promise((r) => setTimeout(r, 50)); // flush the post-import microtask chain
+
+    // No poll interval may be created after cleanup, and no scanning may occur.
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 300);
+    expect(readBarcodes).not.toHaveBeenCalled();
+    expect(onScan).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/share/QrScanner.tsx
+++ b/web/src/share/QrScanner.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+import { Alert, Button, Spin } from 'antd';
+import { parseShareInput } from './link';
+
+/** Scan is hidden entirely when this is false (design §8.1). */
+export async function hasCamera(): Promise<boolean> {
+  if (!navigator.mediaDevices?.enumerateDevices) return false;
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.some((d) => d.kind === 'videoinput');
+  } catch {
+    return false;
+  }
+}
+
+type DetectFn = (video: HTMLVideoElement, canvas: HTMLCanvasElement) => Promise<string | null>;
+
+/** Native BarcodeDetector where present; lazy zxing-wasm otherwise (D6). */
+async function makeDetector(): Promise<DetectFn> {
+  if ('BarcodeDetector' in window) {
+    type BD = { detect(v: HTMLVideoElement): Promise<{ rawValue: string }[]> };
+    const Ctor = (window as unknown as { BarcodeDetector: new (o: object) => BD })
+      .BarcodeDetector;
+    const detector = new Ctor({ formats: ['qr_code'] });
+    return async (video) => {
+      const codes = await detector.detect(video);
+      return codes.length > 0 ? codes[0].rawValue : null;
+    };
+  }
+
+  const [{ prepareZXingModule, readBarcodes }, wasm] = await Promise.all([
+    import('zxing-wasm/reader'),
+    import('zxing-wasm/reader/zxing_reader.wasm?url'),
+  ]);
+  prepareZXingModule({
+    overrides: {
+      locateFile: (path: string, prefix: string) =>
+        path.endsWith('.wasm') ? wasm.default : prefix + path,
+    },
+  });
+  return async (video, canvas) => {
+    if (video.videoWidth === 0) return null;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (ctx === null) return null;
+    ctx.drawImage(video, 0, 0);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const results = await readBarcodes(imageData, { formats: ['QRCode'] });
+    return results.length > 0 ? results[0].text : null;
+  };
+}
+
+export function QrScanner({
+  onScan,
+  onClose,
+}: {
+  onScan: (pubHex: string) => void;
+  onClose: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [denied, setDenied] = useState(false);
+  const [starting, setStarting] = useState(true);
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    (async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+      } catch {
+        if (!cancelled) {
+          setDenied(true);
+          setStarting(false);
+        }
+        return;
+      }
+      if (cancelled || videoRef.current === null) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+      const video = videoRef.current;
+      video.srcObject = stream;
+      try {
+        await video.play();
+      } catch {
+        // jsdom / autoplay restrictions — the poll below still reads frames
+      }
+      setStarting(false);
+      const detect = await makeDetector();
+      if (cancelled) return; // unmounted during the (possibly slow) detector load
+      let busy = false;
+      timer = setInterval(async () => {
+        if (busy || cancelled) return;
+        busy = true;
+        const text = await detect(video, canvasRef.current as HTMLCanvasElement).catch(
+          () => null,
+        );
+        busy = false;
+        if (text === null) return;
+        const pubHex = parseShareInput(text);
+        if (pubHex !== null && !cancelled) {
+          if (timer !== null) clearInterval(timer);
+          onScan(pubHex);
+        }
+      }, 300);
+    })();
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearInterval(timer);
+      if (stream !== null) stream.getTracks().forEach((t) => t.stop());
+    };
+  }, [onScan]);
+
+  if (denied) {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        message="Camera unavailable"
+        description="Camera access was denied. Paste the share link or raw key into the field above instead."
+        action={
+          <Button size="large" onClick={onClose}>
+            Close
+          </Button>
+        }
+      />
+    );
+  }
+  return (
+    <div>
+      {starting && <Spin aria-label="Starting camera" />}
+      <video
+        ref={videoRef}
+        muted
+        playsInline
+        aria-label="Camera preview for QR scanning"
+        style={{ width: '100%' }}
+      />
+      <canvas ref={canvasRef} style={{ display: 'none' }} />
+      <Button size="large" onClick={onClose} style={{ marginTop: 8 }}>
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/web/src/share/RecipientsPane.test.tsx
+++ b/web/src/share/RecipientsPane.test.tsx
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App } from 'antd';
+import type { Recipient } from '../files/db';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+const DEEP_LINK = `https://filekey.example/?pub=${VALID_HEX}`;
+
+const db = {
+  listRecipients: vi.fn<() => Promise<Recipient[]>>(),
+  addRecipient: vi.fn(),
+  renameRecipient: vi.fn().mockResolvedValue(undefined),
+  deleteRecipient: vi.fn().mockResolvedValue(undefined),
+};
+vi.mock('../files/db', () => ({
+  listRecipients: (...a: unknown[]) => db.listRecipients(...(a as [])),
+  addRecipient: (...a: unknown[]) => db.addRecipient(...a),
+  renameRecipient: (...a: unknown[]) => db.renameRecipient(...a),
+  deleteRecipient: (...a: unknown[]) => db.deleteRecipient(...a),
+}));
+
+const validateRecipientKey = vi.fn();
+vi.mock('./validate', () => ({
+  validateRecipientKey: (...a: unknown[]) => validateRecipientKey(...a),
+}));
+
+const hasCamera = vi.fn();
+const qrScannerProps = vi.fn();
+vi.mock('./QrScanner', () => ({
+  hasCamera: () => hasCamera(),
+  QrScanner: (props: { onScan: (hex: string) => void; onClose: () => void }) => {
+    qrScannerProps(props);
+    return <div data-testid="qr-scanner" />;
+  },
+}));
+
+import { RecipientsPane } from './RecipientsPane';
+
+const alice: Recipient = { id: 'id-1', name: 'Alice', pubHex: VALID_HEX, createdTs: 1 };
+
+function renderPane(activePubHex: string | null = null) {
+  return render(
+    <App>
+      <RecipientsPane activePubHex={activePubHex} />
+    </App>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.listRecipients.mockResolvedValue([alice]);
+  db.addRecipient.mockImplementation(async (name: string, pubHex: string) => ({
+    id: 'id-new',
+    name,
+    pubHex: pubHex.toLowerCase(),
+    createdTs: 2,
+  }));
+  validateRecipientKey.mockResolvedValue(true);
+  hasCamera.mockResolvedValue(true);
+});
+
+describe('list', () => {
+  it('shows name and truncated key (04a1…a1b2 format)', async () => {
+    renderPane();
+    const item = (await screen.findByText('Alice')).closest('li') as HTMLElement;
+    expect(within(item).getByText('04a1…a1b2')).toBeInTheDocument();
+  });
+});
+
+describe('add — validated paste field', () => {
+  it('adds a recipient from a raw hex paste', async () => {
+    renderPane();
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Share key or link' }), {
+      target: { value: VALID_HEX },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Recipient name' }), {
+      target: { value: 'Bob' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() =>
+      expect(validateRecipientKey).toHaveBeenCalledWith(VALID_HEX, null),
+    );
+    expect(db.addRecipient).toHaveBeenCalledWith('Bob', VALID_HEX);
+  });
+
+  it('passes activePubHex through to validation (restore protocol)', async () => {
+    const ACTIVE = '04' + 'c3d4'.repeat(66);
+    renderPane(ACTIVE);
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Share key or link' }), {
+      target: { value: VALID_HEX },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() =>
+      expect(validateRecipientKey).toHaveBeenCalledWith(VALID_HEX, ACTIVE),
+    );
+  });
+
+  it('extracts the key from a pasted deep link', async () => {
+    renderPane();
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Share key or link' }), {
+      target: { value: DEEP_LINK },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => expect(db.addRecipient).toHaveBeenCalled());
+    expect(db.addRecipient.mock.calls[0][1]).toBe(VALID_HEX);
+  });
+
+  it('shows live invalid state and disables Add for garbage', async () => {
+    renderPane();
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Share key or link' }), {
+      target: { value: 'not a key' },
+    });
+    expect(screen.getByText('Not a valid Share Key or link')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+    expect(db.addRecipient).not.toHaveBeenCalled();
+  });
+
+  it('reports an off-curve key rejected by the worker dry-run', async () => {
+    validateRecipientKey.mockResolvedValue(false);
+    renderPane();
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Share key or link' }), {
+      target: { value: VALID_HEX },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(
+      await screen.findByText('That is not a valid FileKey Share Key'),
+    ).toBeInTheDocument();
+    expect(db.addRecipient).not.toHaveBeenCalled();
+  });
+});
+
+describe('scan QR', () => {
+  it('hides the Scan button entirely when no camera is present', async () => {
+    hasCamera.mockResolvedValue(false);
+    renderPane();
+    await screen.findByText('Alice');
+    expect(screen.queryByRole('button', { name: 'Scan QR' })).toBeNull();
+  });
+
+  it('opens the scanner and fills the field with the scanned key', async () => {
+    renderPane();
+    fireEvent.click(await screen.findByRole('button', { name: 'Scan QR' }));
+    await screen.findByTestId('qr-scanner');
+    const { onScan } = qrScannerProps.mock.calls[0][0] as {
+      onScan: (hex: string) => void;
+    };
+    onScan(VALID_HEX);
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'Share key or link' })).toHaveValue(
+        VALID_HEX,
+      ),
+    );
+    expect(screen.queryByTestId('qr-scanner')).toBeNull();
+  });
+});
+
+describe('rename and delete', () => {
+  it('renames via a Modal prompt', async () => {
+    renderPane();
+    const item = (await screen.findByText('Alice')).closest('li') as HTMLElement;
+    fireEvent.click(within(item).getByRole('button', { name: 'Rename' }));
+    const modal = await screen.findByRole('dialog');
+    fireEvent.change(within(modal).getByRole('textbox', { name: 'Recipient name' }), {
+      target: { value: 'Alice Work' },
+    });
+    fireEvent.click(within(modal).getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(db.renameRecipient).toHaveBeenCalledWith('id-1', 'Alice Work'),
+    );
+  });
+
+  it('deletes behind a Popconfirm', async () => {
+    renderPane();
+    const item = (await screen.findByText('Alice')).closest('li') as HTMLElement;
+    fireEvent.click(within(item).getByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Yes' }));
+    await waitFor(() => expect(db.deleteRecipient).toHaveBeenCalledWith('id-1'));
+  });
+});

--- a/web/src/share/RecipientsPane.tsx
+++ b/web/src/share/RecipientsPane.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useState } from 'react';
+import { App, Button, Input, List, Modal, Popconfirm, Space, Typography } from 'antd';
+import {
+  addRecipient,
+  deleteRecipient,
+  listRecipients,
+  renameRecipient,
+  type Recipient,
+} from '../files/db';
+import { parseShareInput, truncateKey } from './link';
+import { validateRecipientKey } from './validate';
+import { hasCamera, QrScanner } from './QrScanner';
+
+/**
+ * Validated add control — also reused inline by the per-file recipient picker
+ * (design §8.2). Accepts raw 266-hex or a pasted/scanned deep link.
+ */
+export function AddRecipientControl({
+  activePubHex,
+  onAdded,
+}: {
+  activePubHex: string | null;
+  onAdded: (r: Recipient) => void;
+}) {
+  const { message } = App.useApp();
+  const [value, setValue] = useState('');
+  const [name, setName] = useState('');
+  const [scanOpen, setScanOpen] = useState(false);
+  const [cameraAvailable, setCameraAvailable] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    hasCamera().then(setCameraAvailable);
+  }, []);
+
+  const parsedHex = parseShareInput(value);
+  const invalid = value.trim() !== '' && parsedHex === null;
+
+  const handleScan = useCallback((hex: string) => {
+    setValue(hex);
+    setScanOpen(false);
+  }, []);
+
+  const add = async () => {
+    if (parsedHex === null) return;
+    setSaving(true);
+    try {
+      const valid = await validateRecipientKey(parsedHex, activePubHex);
+      if (!valid) {
+        message.error('That is not a valid FileKey Share Key');
+        return;
+      }
+      const recipient = await addRecipient(name.trim() || truncateKey(parsedHex), parsedHex);
+      setValue('');
+      setName('');
+      message.success('Recipient saved');
+      onAdded(recipient);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      <Input
+        size="large"
+        aria-label="Share key or link"
+        placeholder="Paste a share link or raw key"
+        value={value}
+        status={invalid ? 'error' : undefined}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      {invalid && (
+        <Typography.Text type="danger">Not a valid Share Key or link</Typography.Text>
+      )}
+      <Input
+        size="large"
+        aria-label="Recipient name"
+        placeholder="Name (optional)"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Space wrap>
+        <Button
+          type="primary"
+          size="large"
+          disabled={parsedHex === null}
+          loading={saving}
+          onClick={add}
+        >
+          Add
+        </Button>
+        {cameraAvailable && !scanOpen && (
+          <Button size="large" onClick={() => setScanOpen(true)}>
+            Scan QR
+          </Button>
+        )}
+      </Space>
+      {scanOpen && <QrScanner onScan={handleScan} onClose={() => setScanOpen(false)} />}
+    </Space>
+  );
+}
+
+export function RecipientsPane({ activePubHex }: { activePubHex: string | null }) {
+  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [renaming, setRenaming] = useState<Recipient | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+
+  const refresh = useCallback(() => {
+    listRecipients().then(setRecipients);
+  }, []);
+
+  useEffect(refresh, [refresh]);
+
+  const confirmRename = async () => {
+    if (renaming === null) return;
+    await renameRecipient(renaming.id, renameValue.trim());
+    setRenaming(null);
+    refresh();
+  };
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <AddRecipientControl activePubHex={activePubHex} onAdded={refresh} />
+      <List
+        dataSource={recipients}
+        locale={{
+          emptyText: 'No saved recipients yet. Recipients are stored only on this device.',
+        }}
+        renderItem={(r) => (
+          <List.Item
+            actions={[
+              <Button
+                key="rename"
+                size="large"
+                onClick={() => {
+                  setRenaming(r);
+                  setRenameValue(r.name);
+                }}
+              >
+                Rename
+              </Button>,
+              <Popconfirm
+                key="delete"
+                title={`Delete ${r.name}?`}
+                okText="Yes"
+                onConfirm={async () => {
+                  await deleteRecipient(r.id);
+                  refresh();
+                }}
+              >
+                <Button size="large" danger>
+                  Delete
+                </Button>
+              </Popconfirm>,
+            ]}
+          >
+            <List.Item.Meta
+              title={r.name}
+              description={
+                <Typography.Text type="secondary" style={{ fontFamily: 'monospace' }}>
+                  {truncateKey(r.pubHex)}
+                </Typography.Text>
+              }
+            />
+          </List.Item>
+        )}
+      />
+      <Modal
+        title="Rename recipient"
+        open={renaming !== null}
+        okText="Save"
+        okButtonProps={{ disabled: renameValue.trim() === '' }}
+        onOk={confirmRename}
+        onCancel={() => setRenaming(null)}
+      >
+        <Input
+          size="large"
+          aria-label="Recipient name"
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+        />
+      </Modal>
+    </Space>
+  );
+}

--- a/web/src/share/ShareCenter.test.tsx
+++ b/web/src/share/ShareCenter.test.tsx
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App } from 'antd';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+
+const sessionMock = {
+  locked: false,
+  unlock: vi.fn<() => Promise<boolean>>(),
+  lock: vi.fn(),
+  getSharePubHex: vi.fn<() => Promise<string | null>>(),
+};
+vi.mock('../state/session', () => ({ useSession: () => ({ ...sessionMock }) }));
+vi.mock('./ShareQr', () => ({
+  ShareQr: ({ link }: { link: string }) => <div data-testid="qr" data-link={link} />,
+}));
+// ShareCenter → (Task 8/9) RecipientsPane/inbound → validate → crypto/client, which
+// constructs `new Worker(...)` at module scope; jsdom has no Worker. Mock the singleton.
+vi.mock('../crypto/client', () => ({ rpc: { call: vi.fn() } }));
+
+import { MyShareKeyButton } from './ShareCenter';
+
+function setViewport(desktop: boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: desktop ? /min-width/.test(query) : false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+}
+
+function renderCenter() {
+  return render(
+    <App>
+      <MyShareKeyButton />
+    </App>,
+  );
+}
+
+async function openCenter() {
+  fireEvent.click(screen.getByRole('button', { name: 'My Share Key' }));
+  return await screen.findByRole('dialog');
+}
+
+beforeEach(() => {
+  setViewport(true); // desktop Modal by default
+  sessionMock.locked = false;
+  sessionMock.unlock.mockReset().mockResolvedValue(true);
+  sessionMock.getSharePubHex.mockReset().mockResolvedValue(VALID_HEX);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+  delete (navigator as unknown as Record<string, unknown>).share;
+});
+
+describe('lock gating', () => {
+  it('fires unlock() directly from the click when locked and shows a spinner', async () => {
+    sessionMock.locked = true;
+    let release!: (ok: boolean) => void;
+    sessionMock.unlock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = (ok) => {
+            sessionMock.locked = !ok;
+            resolve(ok);
+          };
+        }),
+    );
+    renderCenter();
+    const dialog = await openCenter();
+    expect(sessionMock.unlock).toHaveBeenCalledTimes(1);
+    expect(within(dialog).getByLabelText('Waiting for passkey')).toBeInTheDocument();
+
+    release(true);
+    expect(
+      await within(dialog).findByRole('button', { name: 'Copy link' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not call unlock() when already unlocked', async () => {
+    renderCenter();
+    await openCenter();
+    expect(sessionMock.unlock).not.toHaveBeenCalled();
+  });
+
+  it('renders inline retry + requirements when unlock fails, and retry re-prompts', async () => {
+    sessionMock.locked = true;
+    sessionMock.unlock.mockResolvedValueOnce(false);
+    renderCenter();
+    const dialog = await openCenter();
+    const retry = await within(dialog).findByRole('button', { name: 'Try again' });
+    expect(within(dialog).getByText('Passkey authentication failed')).toBeInTheDocument();
+    expect(within(dialog).getByText(/requirements/i)).toBeInTheDocument();
+
+    sessionMock.unlock.mockImplementation(async () => {
+      sessionMock.locked = false;
+      return true;
+    });
+    fireEvent.click(retry);
+    expect(
+      await within(dialog).findByRole('button', { name: 'Copy link' }),
+    ).toBeInTheDocument();
+    expect(sessionMock.unlock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('My Key pane — capability-detected ordering (D6)', () => {
+  it('without navigator.share: Copy link is the primary action, no Share my link', async () => {
+    renderCenter();
+    const dialog = await openCenter();
+    const copy = await within(dialog).findByRole('button', { name: 'Copy link' });
+    expect(copy.className).toContain('ant-btn-primary');
+    expect(within(dialog).queryByRole('button', { name: 'Share my link' })).toBeNull();
+  });
+
+  it('with navigator.share: Share my link is primary and calls share with the deep link', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    renderCenter();
+    const dialog = await openCenter();
+    const btn = await within(dialog).findByRole('button', { name: 'Share my link' });
+    expect(btn.className).toContain('ant-btn-primary');
+    fireEvent.click(btn);
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        url: `${location.origin}/?pub=${VALID_HEX}`,
+        title: 'FileKey',
+        text: 'Send me encrypted files with FileKey',
+      }),
+    );
+  });
+
+  it('swallows AbortError when the user dismisses the share sheet', async () => {
+    const share = vi.fn().mockRejectedValue(new DOMException('cancelled', 'AbortError'));
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    renderCenter();
+    const dialog = await openCenter();
+    fireEvent.click(await within(dialog).findByRole('button', { name: 'Share my link' }));
+    await waitFor(() => expect(share).toHaveBeenCalled());
+    expect(screen.queryByText('Could not open the share sheet')).toBeNull();
+  });
+
+  it('copies the deep link and announces Copied via an aria-live toast', async () => {
+    renderCenter();
+    const dialog = await openCenter();
+    fireEvent.click(await within(dialog).findByRole('button', { name: 'Copy link' }));
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${location.origin}/?pub=${VALID_HEX}`,
+      ),
+    );
+    const toast = await screen.findByText('Copied');
+    expect(
+      toast.closest('[role="alert"], [aria-live="polite"], [aria-live="assertive"]'),
+    ).not.toBeNull();
+  });
+
+  it('renders the QR of the deep link and a collapsed raw-key row with Copy', async () => {
+    renderCenter();
+    const dialog = await openCenter();
+    await within(dialog).findByRole('button', { name: 'Copy link' });
+    expect(within(dialog).getByTestId('qr').dataset.link).toBe(
+      `${location.origin}/?pub=${VALID_HEX}`,
+    );
+    // collapsed by default: hex not visible until the Raw key row is expanded
+    expect(within(dialog).queryByText(VALID_HEX)).toBeNull();
+    fireEvent.click(within(dialog).getByText('Raw key'));
+    expect(await within(dialog).findByText(VALID_HEX)).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Copy raw key' }));
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(VALID_HEX),
+    );
+  });
+});
+
+describe('container by breakpoint', () => {
+  it('uses a bottom Drawer on mobile and a Modal on desktop', async () => {
+    setViewport(false);
+    const { unmount } = renderCenter();
+    fireEvent.click(screen.getByRole('button', { name: 'My Share Key' }));
+    await waitFor(() =>
+      expect(document.querySelector('.ant-drawer-bottom')).not.toBeNull(),
+    );
+    expect(document.querySelector('.ant-modal')).toBeNull();
+    unmount();
+
+    setViewport(true);
+    renderCenter();
+    fireEvent.click(screen.getByRole('button', { name: 'My Share Key' }));
+    await waitFor(() => expect(document.querySelector('.ant-modal')).not.toBeNull());
+    expect(document.querySelector('.ant-drawer-bottom')).toBeNull();
+  });
+});

--- a/web/src/share/ShareCenter.test.tsx
+++ b/web/src/share/ShareCenter.test.tsx
@@ -113,6 +113,18 @@ describe('lock gating', () => {
     ).toBeInTheDocument();
     expect(sessionMock.unlock).toHaveBeenCalledTimes(2);
   });
+
+  it('clears the spinner and shows inline retry when unlock() rejects (worker key-derivation failure)', async () => {
+    sessionMock.locked = true;
+    sessionMock.unlock.mockRejectedValueOnce(new Error('prf_to_key failed'));
+    renderCenter();
+    const dialog = await openCenter();
+    expect(
+      await within(dialog).findByRole('button', { name: 'Try again' }),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('Passkey authentication failed')).toBeInTheDocument();
+    expect(within(dialog).queryByLabelText('Waiting for passkey')).toBeNull();
+  });
 });
 
 describe('My Key pane — capability-detected ordering (D6)', () => {

--- a/web/src/share/ShareCenter.test.tsx
+++ b/web/src/share/ShareCenter.test.tsx
@@ -17,6 +17,12 @@ vi.mock('./ShareQr', () => ({
 // ShareCenter → (Task 8/9) RecipientsPane/inbound → validate → crypto/client, which
 // constructs `new Worker(...)` at module scope; jsdom has no Worker. Mock the singleton.
 vi.mock('../crypto/client', () => ({ rpc: { call: vi.fn() } }));
+// RecipientsPane renders live in the pane-switch test below.
+vi.mock('../files/db', () => ({ listRecipients: vi.fn().mockResolvedValue([]) }));
+vi.mock('./QrScanner', () => ({
+  hasCamera: vi.fn().mockResolvedValue(false),
+  QrScanner: () => null,
+}));
 
 import { MyShareKeyButton } from './ShareCenter';
 
@@ -194,5 +200,18 @@ describe('container by breakpoint', () => {
     fireEvent.click(screen.getByRole('button', { name: 'My Share Key' }));
     await waitFor(() => expect(document.querySelector('.ant-modal')).not.toBeNull());
     expect(document.querySelector('.ant-drawer-bottom')).toBeNull();
+  });
+});
+
+describe('pane switching', () => {
+  it('switches to the Recipients pane via the segmented control', async () => {
+    renderCenter();
+    const dialog = await openCenter();
+    await within(dialog).findByRole('button', { name: 'Copy link' });
+    fireEvent.click(within(dialog).getByText('Recipients'));
+    expect(
+      await within(dialog).findByRole('textbox', { name: 'Share key or link' }),
+    ).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: 'Copy link' })).toBeNull();
   });
 });

--- a/web/src/share/ShareCenter.tsx
+++ b/web/src/share/ShareCenter.tsx
@@ -36,10 +36,18 @@ export function MyShareKeyButton() {
     setUnlocking(true);
     // unlock() must be invoked synchronously inside the user gesture —
     // WebAuthn requires user activation (design §5.2).
-    unlock().then((ok) => {
-      setUnlocking(false);
-      if (!ok) setAuthFailed(true);
-    });
+    unlock()
+      .then((ok) => {
+        setUnlocking(false);
+        if (!ok) setAuthFailed(true);
+      })
+      .catch(() => {
+        // worker key-derivation rejection (prf_to_key/set_seed) is not caught
+        // by session.unlock() — route into the same inline retry as a failed
+        // unlock so the spinner never gets stuck (§9, no dead-end).
+        setUnlocking(false);
+        setAuthFailed(true);
+      });
   };
 
   const openCenter = () => {

--- a/web/src/share/ShareCenter.tsx
+++ b/web/src/share/ShareCenter.tsx
@@ -8,12 +8,14 @@ import {
   Grid,
   Modal,
   Result,
+  Segmented,
   Space,
   Spin,
   Typography,
 } from 'antd';
 import { useSession } from '../state/session';
 import { shareLink } from './link';
+import { RecipientsPane } from './RecipientsPane';
 import { ShareQr } from './ShareQr';
 
 const SHARE_TITLE = 'FileKey';
@@ -141,15 +143,30 @@ export function ShareCenter({
   );
 }
 
-// activePubHex is consumed by the Recipients pane (Task 8); referenced here so
-// the prop is part of the component contract from the start.
 function ShareCenterBody({
   pubHex,
+  activePubHex,
 }: {
   pubHex: string;
   activePubHex: string | null;
 }) {
-  return <MyKeyPane pubHex={pubHex} />;
+  const [pane, setPane] = useState<'My Key' | 'Recipients'>('My Key');
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Segmented
+        block
+        size="large"
+        options={['My Key', 'Recipients']}
+        value={pane}
+        onChange={(v) => setPane(v as 'My Key' | 'Recipients')}
+      />
+      {pane === 'My Key' ? (
+        <MyKeyPane pubHex={pubHex} />
+      ) : (
+        <RecipientsPane activePubHex={activePubHex} />
+      )}
+    </Space>
+  );
 }
 
 function MyKeyPane({ pubHex }: { pubHex: string }) {

--- a/web/src/share/ShareCenter.tsx
+++ b/web/src/share/ShareCenter.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from 'antd';
 import { useSession } from '../state/session';
+import { useInboundShare } from './inbound';
 import { shareLink } from './link';
 import { RecipientsPane } from './RecipientsPane';
 import { ShareQr } from './ShareQr';
@@ -22,7 +23,9 @@ const SHARE_TITLE = 'FileKey';
 const SHARE_TEXT = 'Send me encrypted files with FileKey';
 
 /** Header action (D3). Owns open/unlock state; WebAuthn fires from the click. */
-export function MyShareKeyButton({ activePubHex = null }: { activePubHex?: string | null }) {
+export function MyShareKeyButton() {
+  const inbound = useInboundShare();
+  const activePubHex = inbound?.pubHex ?? null;
   const { locked, unlock } = useSession();
   const [open, setOpen] = useState(false);
   const [unlocking, setUnlocking] = useState(false);

--- a/web/src/share/ShareCenter.tsx
+++ b/web/src/share/ShareCenter.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState } from 'react';
+import {
+  App,
+  Button,
+  Collapse,
+  Drawer,
+  Flex,
+  Grid,
+  Modal,
+  Result,
+  Space,
+  Spin,
+  Typography,
+} from 'antd';
+import { useSession } from '../state/session';
+import { shareLink } from './link';
+import { ShareQr } from './ShareQr';
+
+const SHARE_TITLE = 'FileKey';
+const SHARE_TEXT = 'Send me encrypted files with FileKey';
+
+/** Header action (D3). Owns open/unlock state; WebAuthn fires from the click. */
+export function MyShareKeyButton({ activePubHex = null }: { activePubHex?: string | null }) {
+  const { locked, unlock } = useSession();
+  const [open, setOpen] = useState(false);
+  const [unlocking, setUnlocking] = useState(false);
+  const [authFailed, setAuthFailed] = useState(false);
+
+  const beginUnlock = () => {
+    setAuthFailed(false);
+    setUnlocking(true);
+    // unlock() must be invoked synchronously inside the user gesture —
+    // WebAuthn requires user activation (design §5.2).
+    unlock().then((ok) => {
+      setUnlocking(false);
+      if (!ok) setAuthFailed(true);
+    });
+  };
+
+  const openCenter = () => {
+    setAuthFailed(false);
+    setOpen(true);
+    if (locked) beginUnlock();
+  };
+
+  return (
+    <>
+      <Button size="large" onClick={openCenter}>
+        My Share Key
+      </Button>
+      <ShareCenter
+        open={open}
+        unlocking={unlocking}
+        authFailed={authFailed}
+        activePubHex={activePubHex}
+        onRetry={beginUnlock}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+type ShareCenterProps = {
+  open: boolean;
+  unlocking: boolean;
+  authFailed: boolean;
+  activePubHex: string | null;
+  onRetry: () => void;
+  onClose: () => void;
+};
+
+/** Bottom Drawer on mobile, Modal on desktop — same children (§8.1). */
+export function ShareCenter({
+  open,
+  unlocking,
+  authFailed,
+  activePubHex,
+  onRetry,
+  onClose,
+}: ShareCenterProps) {
+  const screens = Grid.useBreakpoint();
+  const isMobile = !screens.md;
+  const { locked, getSharePubHex } = useSession();
+  const [pubHex, setPubHex] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && !locked) {
+      getSharePubHex().then(setPubHex);
+    }
+    if (!open) setPubHex(null);
+  }, [open, locked, getSharePubHex]);
+
+  let body: JSX.Element;
+  if (authFailed) {
+    body = (
+      <Result
+        status="warning"
+        title="Passkey authentication failed"
+        subTitle="Your Share Key stays locked until you authenticate."
+        extra={
+          <Space direction="vertical" size="middle">
+            <Button type="primary" size="large" onClick={onRetry}>
+              Try again
+            </Button>
+            <Typography.Paragraph type="secondary">
+              FileKey requirements: a device passkey (Face ID, Touch ID, Windows Hello, or
+              Android screen lock) with PRF support — iOS 17+, Android 14+, or a current
+              Chrome, Edge, or Safari.
+            </Typography.Paragraph>
+          </Space>
+        }
+      />
+    );
+  } else if (locked || unlocking || pubHex === null) {
+    body = (
+      <div style={{ textAlign: 'center', padding: 48 }} aria-label="Waiting for passkey">
+        <Spin size="large" />
+      </div>
+    );
+  } else {
+    body = <ShareCenterBody pubHex={pubHex} activePubHex={activePubHex} />;
+  }
+
+  if (isMobile) {
+    return (
+      <Drawer
+        title="My Share Key"
+        placement="bottom"
+        height="85dvh"
+        open={open}
+        onClose={onClose}
+      >
+        {body}
+      </Drawer>
+    );
+  }
+  return (
+    <Modal title="My Share Key" open={open} onCancel={onClose} footer={null} width={720}>
+      {body}
+    </Modal>
+  );
+}
+
+// activePubHex is consumed by the Recipients pane (Task 8); referenced here so
+// the prop is part of the component contract from the start.
+function ShareCenterBody({
+  pubHex,
+}: {
+  pubHex: string;
+  activePubHex: string | null;
+}) {
+  return <MyKeyPane pubHex={pubHex} />;
+}
+
+function MyKeyPane({ pubHex }: { pubHex: string }) {
+  const { message } = App.useApp();
+  const link = shareLink(pubHex);
+  const canWebShare = typeof navigator.share === 'function';
+
+  const copyLink = async () => {
+    await navigator.clipboard.writeText(link);
+    message.success('Copied');
+  };
+  const copyRawKey = async () => {
+    await navigator.clipboard.writeText(pubHex);
+    message.success('Copied');
+  };
+  const shareViaSheet = async () => {
+    try {
+      await navigator.share({ url: link, title: SHARE_TITLE, text: SHARE_TEXT });
+    } catch (e) {
+      // user-dismissed share sheet is not an error (§9)
+      if ((e as DOMException).name !== 'AbortError') {
+        message.error('Could not open the share sheet');
+      }
+    }
+  };
+
+  return (
+    // Two-column on the 720px desktop Modal (QR beside the actions, sized for
+    // scanning a monitor — §8.1); the narrow mobile Drawer wraps this into a
+    // single column. Actions come first in DOM order for a logical tab order.
+    <Flex wrap gap="large" align="flex-start">
+      <Space direction="vertical" size="large" style={{ flex: 1, minWidth: 260 }}>
+        <Space wrap>
+          {canWebShare ? (
+            <>
+              <Button type="primary" size="large" onClick={shareViaSheet}>
+                Share my link
+              </Button>
+              <Button size="large" onClick={copyLink}>
+                Copy link
+              </Button>
+            </>
+          ) : (
+            // copy-first ordering when Web Share is absent (D6, §8.1)
+            <Button type="primary" size="large" onClick={copyLink}>
+              Copy link
+            </Button>
+          )}
+        </Space>
+        <Collapse
+          ghost
+          items={[
+            {
+              key: 'raw',
+              label: 'Raw key',
+              children: (
+                <Space direction="vertical" style={{ width: '100%' }}>
+                  <Typography.Text
+                    style={{ wordBreak: 'break-all', fontFamily: 'monospace' }}
+                  >
+                    {pubHex}
+                  </Typography.Text>
+                  <Button size="large" onClick={copyRawKey}>
+                    Copy raw key
+                  </Button>
+                </Space>
+              ),
+            },
+          ]}
+        />
+      </Space>
+      <ShareQr link={link} />
+    </Flex>
+  );
+}

--- a/web/src/share/ShareFileAction.test.tsx
+++ b/web/src/share/ShareFileAction.test.tsx
@@ -30,10 +30,11 @@ vi.mock('./shareFile', async (importOriginal) => {
   return {
     ...actual,
     encryptForRecipient: (...a: unknown[]) => encryptForRecipient(...a),
-    saveBlob: vi.fn(),
   };
 });
-import { saveBlob } from './shareFile';
+
+const downloadBlob = vi.fn();
+vi.mock('../files/save', () => ({ downloadBlob: (...a: unknown[]) => downloadBlob(...a) }));
 
 vi.mock('./RecipientsPane', () => ({
   AddRecipientControl: ({ onAdded }: { onAdded: (r: Recipient) => void }) => (
@@ -154,6 +155,18 @@ describe('picker flow', () => {
     expect(await within(dialog).findByRole('combobox')).toBeInTheDocument();
     expect(sessionMock.unlock).toHaveBeenCalledTimes(2);
   });
+
+  it('clears the spinner and shows inline retry when unlock() rejects (worker key-derivation failure)', async () => {
+    sessionMock.locked = true;
+    sessionMock.unlock.mockRejectedValueOnce(new Error('prf_to_key failed'));
+    renderAction();
+    const dialog = await openPicker();
+    expect(
+      await within(dialog).findByRole('button', { name: 'Try again' }),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('Passkey authentication failed')).toBeInTheDocument();
+    expect(within(dialog).queryByLabelText('Waiting for passkey')).toBeNull();
+  });
 });
 
 describe('result actions — capability-detected ordering (D6, §8.2)', () => {
@@ -205,9 +218,7 @@ describe('result actions — capability-detected ordering (D6, §8.2)', () => {
     const saveBtn = within(dialog).getByRole('button', { name: 'Save' });
     expect(saveBtn.className).toContain('ant-btn-primary');
     fireEvent.click(saveBtn);
-    expect(saveBlob).toHaveBeenCalledTimes(1);
-    expect((saveBlob as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe(
-      'photo.jpg.shared_filekey',
-    );
+    expect(downloadBlob).toHaveBeenCalledTimes(1);
+    expect(downloadBlob.mock.calls[0][1]).toBe('photo.jpg.shared_filekey');
   });
 });

--- a/web/src/share/ShareFileAction.test.tsx
+++ b/web/src/share/ShareFileAction.test.tsx
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App } from 'antd';
+import type { FileJob } from '../files/ops';
+import type { Recipient } from '../files/db';
+import { InboundShareContext } from './inbound';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+const OTHER_HEX = '04' + 'c3d4'.repeat(66);
+
+const sessionMock = {
+  locked: false,
+  unlock: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+  lock: vi.fn(),
+  getSharePubHex: vi.fn(),
+};
+vi.mock('../state/session', () => ({ useSession: () => ({ ...sessionMock }) }));
+
+const db = { listRecipients: vi.fn<() => Promise<Recipient[]>>() };
+vi.mock('../files/db', () => ({ listRecipients: () => db.listRecipients() }));
+
+// `vi.mock('./shareFile', importOriginal)` below re-loads the REAL shareFile.ts,
+// which imports `../crypto/client` (runs `new Worker(...)` at module scope); jsdom
+// has no Worker. Mock the singleton so the importOriginal() call cannot crash.
+vi.mock('../crypto/client', () => ({ rpc: { call: vi.fn() } }));
+
+const encryptForRecipient = vi.fn();
+vi.mock('./shareFile', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./shareFile')>();
+  return {
+    ...actual,
+    encryptForRecipient: (...a: unknown[]) => encryptForRecipient(...a),
+    saveBlob: vi.fn(),
+  };
+});
+import { saveBlob } from './shareFile';
+
+vi.mock('./RecipientsPane', () => ({
+  AddRecipientControl: ({ onAdded }: { onAdded: (r: Recipient) => void }) => (
+    <button
+      type="button"
+      onClick={() => onAdded({ id: 'id-new', name: 'Carol', pubHex: OTHER_HEX, createdTs: 3 })}
+    >
+      mock-add-recipient
+    </button>
+  ),
+}));
+
+import { ShareFileAction } from './ShareFileAction';
+
+const job: FileJob = {
+  id: 'job-1',
+  name: 'photo.jpg.filekey',
+  kind: 'encrypted',
+  status: 'done',
+  outName: 'photo.jpg',
+  data: new Uint8Array([1, 2, 3]).buffer,
+};
+
+const alice: Recipient = { id: 'id-1', name: 'Alice', pubHex: VALID_HEX, createdTs: 1 };
+
+function renderAction(inbound: { pubHex: string; recipientName: string | null } | null = null) {
+  return render(
+    <App>
+      <InboundShareContext.Provider value={inbound}>
+        <ShareFileAction job={job} />
+      </InboundShareContext.Provider>
+    </App>,
+  );
+}
+
+async function openPicker() {
+  fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+  return await screen.findByRole('dialog');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionMock.locked = false;
+  sessionMock.unlock.mockResolvedValue(true);
+  db.listRecipients.mockResolvedValue([alice]);
+  encryptForRecipient.mockResolvedValue(new Uint8Array(133 + 16 + 4).buffer);
+  delete (navigator as unknown as Record<string, unknown>).share;
+  delete (navigator as unknown as Record<string, unknown>).canShare;
+});
+
+describe('picker flow', () => {
+  it('encrypts to the selected saved recipient and shows the result filename', async () => {
+    const dialog = await (renderAction(), openPicker());
+    fireEvent.mouseDown(within(dialog).getByRole('combobox'));
+    fireEvent.click(await screen.findByTitle('Alice (04a1…a1b2)'));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Encrypt for recipient' }));
+    await waitFor(() =>
+      expect(encryptForRecipient).toHaveBeenCalledWith(job.data, VALID_HEX),
+    );
+    expect(
+      await within(dialog).findByText('photo.jpg.shared_filekey'),
+    ).toBeInTheDocument();
+  });
+
+  it('offers New recipient inline and uses the newly added key', async () => {
+    const dialog = await (renderAction(), openPicker());
+    fireEvent.mouseDown(within(dialog).getByRole('combobox'));
+    fireEvent.click(await screen.findByTitle('New recipient…'));
+    fireEvent.click(await within(dialog).findByRole('button', { name: 'mock-add-recipient' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Encrypt for recipient' }));
+    await waitFor(() =>
+      expect(encryptForRecipient).toHaveBeenCalledWith(job.data, OTHER_HEX),
+    );
+  });
+
+  it('preselects the inbound ?pub= key', async () => {
+    renderAction({ pubHex: OTHER_HEX, recipientName: null });
+    const dialog = await openPicker();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Encrypt for recipient' }));
+    await waitFor(() =>
+      expect(encryptForRecipient).toHaveBeenCalledWith(job.data, OTHER_HEX),
+    );
+  });
+
+  it('fires unlock() from the Share click when locked', async () => {
+    sessionMock.locked = true;
+    let release!: (ok: boolean) => void;
+    sessionMock.unlock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = (ok) => {
+            sessionMock.locked = !ok;
+            resolve(ok);
+          };
+        }),
+    );
+    renderAction();
+    const dialog = await openPicker();
+    expect(sessionMock.unlock).toHaveBeenCalledTimes(1);
+    expect(within(dialog).getByLabelText('Waiting for passkey')).toBeInTheDocument();
+    release(true);
+    expect(await within(dialog).findByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('shows inline retry when unlock fails, and retry re-prompts (§9, no dead-end)', async () => {
+    sessionMock.locked = true;
+    sessionMock.unlock.mockResolvedValueOnce(false);
+    renderAction();
+    const dialog = await openPicker();
+    const retry = await within(dialog).findByRole('button', { name: 'Try again' });
+    expect(within(dialog).getByText('Passkey authentication failed')).toBeInTheDocument();
+
+    sessionMock.unlock.mockImplementation(async () => {
+      sessionMock.locked = false;
+      return true;
+    });
+    fireEvent.click(retry);
+    expect(await within(dialog).findByRole('combobox')).toBeInTheDocument();
+    expect(sessionMock.unlock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('result actions — capability-detected ordering (D6, §8.2)', () => {
+  async function encryptToResult(dialog: HTMLElement) {
+    fireEvent.mouseDown(within(dialog).getByRole('combobox'));
+    fireEvent.click(await screen.findByTitle('Alice (04a1…a1b2)'));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Encrypt for recipient' }));
+    await within(dialog).findByText('photo.jpg.shared_filekey');
+  }
+
+  it('share-first when canShare({files}) is true; shares the File', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    Object.defineProperty(navigator, 'canShare', {
+      value: vi.fn().mockReturnValue(true),
+      configurable: true,
+    });
+    const dialog = await (renderAction(), openPicker());
+    await encryptToResult(dialog);
+    const shareBtn = within(dialog).getByRole('button', { name: 'Share file' });
+    expect(shareBtn.className).toContain('ant-btn-primary');
+    fireEvent.click(shareBtn);
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+    const { files } = share.mock.calls[0][0] as { files: File[] };
+    expect(files[0].name).toBe('photo.jpg.shared_filekey');
+    expect(files[0].type).toBe('application/octet-stream');
+  });
+
+  it('swallows AbortError when the user dismisses the share sheet', async () => {
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(new DOMException('cancelled', 'AbortError')),
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'canShare', {
+      value: vi.fn().mockReturnValue(true),
+      configurable: true,
+    });
+    const dialog = await (renderAction(), openPicker());
+    await encryptToResult(dialog);
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Share file' }));
+    await waitFor(() => expect(navigator.share).toHaveBeenCalled());
+    expect(screen.queryByText('Could not open the share sheet')).toBeNull();
+  });
+
+  it('save-only when file sharing is unavailable', async () => {
+    const dialog = await (renderAction(), openPicker());
+    await encryptToResult(dialog);
+    expect(within(dialog).queryByRole('button', { name: 'Share file' })).toBeNull();
+    const saveBtn = within(dialog).getByRole('button', { name: 'Save' });
+    expect(saveBtn.className).toContain('ant-btn-primary');
+    fireEvent.click(saveBtn);
+    expect(saveBlob).toHaveBeenCalledTimes(1);
+    expect((saveBlob as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe(
+      'photo.jpg.shared_filekey',
+    );
+  });
+});

--- a/web/src/share/ShareFileAction.tsx
+++ b/web/src/share/ShareFileAction.tsx
@@ -6,7 +6,8 @@ import type { FileJob } from '../files/ops';
 import { truncateKey } from './link';
 import { useInboundShare } from './inbound';
 import { AddRecipientControl } from './RecipientsPane';
-import { encryptForRecipient, saveBlob, sharedFileName } from './shareFile';
+import { encryptForRecipient, sharedFileName } from './shareFile';
+import { downloadBlob } from '../files/save';
 
 const NEW_RECIPIENT = '__new__';
 
@@ -29,10 +30,18 @@ export function ShareFileAction({ job }: { job: FileJob }) {
     setAuthFailed(false);
     setUnlocking(true);
     // WebAuthn must fire from the user gesture (design §5.2)
-    unlock().then((ok) => {
-      setUnlocking(false);
-      if (!ok) setAuthFailed(true);
-    });
+    unlock()
+      .then((ok) => {
+        setUnlocking(false);
+        if (!ok) setAuthFailed(true);
+      })
+      .catch(() => {
+        // worker key-derivation rejection (prf_to_key/set_seed) is not caught
+        // by session.unlock() — route into the same inline retry as a failed
+        // unlock so the spinner never gets stuck (§9, no dead-end).
+        setUnlocking(false);
+        setAuthFailed(true);
+      });
   };
 
   const openShare = () => {
@@ -129,7 +138,7 @@ export function ShareFileAction({ job }: { job: FileJob }) {
           <Button
             type={result.canShareFile ? 'default' : 'primary'}
             size="large"
-            onClick={() => saveBlob(result.blob, result.filename)}
+            onClick={() => downloadBlob(result.blob, result.filename)}
           >
             Save
           </Button>

--- a/web/src/share/ShareFileAction.tsx
+++ b/web/src/share/ShareFileAction.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { App, Button, Modal, Result, Select, Space, Spin, Typography } from 'antd';
+import { useSession } from '../state/session';
+import { listRecipients, type Recipient } from '../files/db';
+import type { FileJob } from '../files/ops';
+import { truncateKey } from './link';
+import { useInboundShare } from './inbound';
+import { AddRecipientControl } from './RecipientsPane';
+import { encryptForRecipient, saveBlob, sharedFileName } from './shareFile';
+
+const NEW_RECIPIENT = '__new__';
+
+type ShareResult = { blob: Blob; filename: string; canShareFile: boolean };
+
+/** Per-file Share action (design §8.2) — picker → shared_ecdh_enc → Share/Save. */
+export function ShareFileAction({ job }: { job: FileJob }) {
+  const { message } = App.useApp();
+  const { locked, unlock } = useSession();
+  const inbound = useInboundShare();
+  const [open, setOpen] = useState(false);
+  const [unlocking, setUnlocking] = useState(false);
+  const [authFailed, setAuthFailed] = useState(false);
+  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [selected, setSelected] = useState<string | null>(inbound?.pubHex ?? null);
+  const [working, setWorking] = useState(false);
+  const [result, setResult] = useState<ShareResult | null>(null);
+
+  const beginUnlock = () => {
+    setAuthFailed(false);
+    setUnlocking(true);
+    // WebAuthn must fire from the user gesture (design §5.2)
+    unlock().then((ok) => {
+      setUnlocking(false);
+      if (!ok) setAuthFailed(true);
+    });
+  };
+
+  const openShare = () => {
+    setResult(null);
+    setAuthFailed(false);
+    setSelected(inbound?.pubHex ?? null);
+    setOpen(true);
+    listRecipients().then(setRecipients);
+    if (locked) beginUnlock();
+  };
+
+  const encrypt = async () => {
+    if (selected === null || selected === NEW_RECIPIENT || job.data === undefined) return;
+    setWorking(true);
+    try {
+      const out = await encryptForRecipient(job.data, selected);
+      const filename = sharedFileName(job);
+      const blob = new Blob([out], { type: 'application/octet-stream' });
+      const probe = new File([blob], filename, { type: 'application/octet-stream' });
+      const canShareFile = navigator.canShare?.({ files: [probe] }) === true;
+      setResult({ blob, filename, canShareFile });
+    } catch (e) {
+      message.error(e instanceof Error ? e.message : 'Sharing failed');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const shareOut = async () => {
+    if (result === null) return;
+    const file = new File([result.blob], result.filename, {
+      type: 'application/octet-stream',
+    });
+    try {
+      await navigator.share({ files: [file] });
+    } catch (e) {
+      // user-dismissed share sheet is not an error (§9)
+      if ((e as DOMException).name !== 'AbortError') {
+        message.error('Could not open the share sheet');
+      }
+    }
+  };
+
+  const options = [
+    ...(inbound !== null && recipients.every((r) => r.pubHex !== inbound.pubHex)
+      ? [
+          {
+            value: inbound.pubHex,
+            title: `From link (${truncateKey(inbound.pubHex)})`,
+            label: `From link (${truncateKey(inbound.pubHex)})`,
+          },
+        ]
+      : []),
+    ...recipients.map((r) => ({
+      value: r.pubHex,
+      title: `${r.name} (${truncateKey(r.pubHex)})`,
+      label: `${r.name} (${truncateKey(r.pubHex)})`,
+    })),
+    { value: NEW_RECIPIENT, title: 'New recipient…', label: 'New recipient…' },
+  ];
+
+  let body: JSX.Element;
+  if (authFailed) {
+    // §9: inline retry — never a dead-end
+    body = (
+      <Result
+        status="warning"
+        title="Passkey authentication failed"
+        subTitle="Sharing needs your passkey."
+        extra={
+          <Button type="primary" size="large" onClick={beginUnlock}>
+            Try again
+          </Button>
+        }
+      />
+    );
+  } else if (locked || unlocking) {
+    body = (
+      <div style={{ textAlign: 'center', padding: 48 }}>
+        <Spin size="large" aria-label="Waiting for passkey" />
+      </div>
+    );
+  } else if (result !== null) {
+    body = (
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Typography.Text>{result.filename}</Typography.Text>
+        <Space wrap>
+          {result.canShareFile && (
+            // share-first ordering where file share is available (D6)
+            <Button type="primary" size="large" onClick={shareOut}>
+              Share file
+            </Button>
+          )}
+          <Button
+            type={result.canShareFile ? 'default' : 'primary'}
+            size="large"
+            onClick={() => saveBlob(result.blob, result.filename)}
+          >
+            Save
+          </Button>
+        </Space>
+      </Space>
+    );
+  } else {
+    body = (
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Select
+          aria-label="Recipient"
+          size="large"
+          style={{ width: '100%' }}
+          placeholder="Choose a recipient"
+          value={selected}
+          options={options}
+          onChange={setSelected}
+        />
+        {selected === NEW_RECIPIENT && (
+          <AddRecipientControl
+            activePubHex={inbound?.pubHex ?? null}
+            onAdded={(r) => {
+              setRecipients((prev) => [...prev, r]);
+              setSelected(r.pubHex);
+            }}
+          />
+        )}
+        <Button
+          type="primary"
+          size="large"
+          loading={working}
+          disabled={selected === null || selected === NEW_RECIPIENT}
+          onClick={encrypt}
+        >
+          Encrypt for recipient
+        </Button>
+      </Space>
+    );
+  }
+
+  return (
+    <>
+      <Button size="large" onClick={openShare}>
+        Share
+      </Button>
+      <Modal
+        title={`Share ${job.outName ?? job.name}`}
+        open={open}
+        onCancel={() => setOpen(false)}
+        footer={null}
+      >
+        {body}
+      </Modal>
+    </>
+  );
+}

--- a/web/src/share/ShareQr.test.tsx
+++ b/web/src/share/ShareQr.test.tsx
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const toCanvas = vi.fn();
+vi.mock('qrcode', () => ({ default: { toCanvas: (...args: unknown[]) => toCanvas(...args) } }));
+
+import { ShareQr } from './ShareQr';
+
+const LINK = `https://filekey.example/?pub=${'04' + 'a1b2'.repeat(66)}`;
+
+beforeEach(() => {
+  toCanvas.mockReset();
+  toCanvas.mockResolvedValue(undefined);
+});
+
+describe('ShareQr', () => {
+  it('renders an accessible canvas and draws the deep link into it', async () => {
+    render(<ShareQr link={LINK} />);
+    const canvas = screen.getByRole('img', { name: 'QR code of your FileKey share link' });
+    await waitFor(() => expect(toCanvas).toHaveBeenCalledTimes(1));
+    const [canvasArg, text, opts] = toCanvas.mock.calls[0] as [
+      HTMLCanvasElement,
+      string,
+      { width: number },
+    ];
+    expect(canvasArg).toBe(canvas);
+    expect(text).toBe(LINK); // the DEEP LINK, never raw hex
+    expect(opts.width).toBe(Math.min(320, Math.floor(window.innerWidth * 0.8)));
+  });
+
+  it('falls back to the copyable link text when rendering fails', async () => {
+    toCanvas.mockRejectedValueOnce(new Error('no canvas 2d'));
+    render(<ShareQr link={LINK} />);
+    expect(await screen.findByText(LINK)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('img', { name: 'QR code of your FileKey share link' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/share/ShareQr.tsx
+++ b/web/src/share/ShareQr.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react';
+import { Typography } from 'antd';
+import QRCode from 'qrcode';
+
+/**
+ * QR of the ?pub= deep link (D2) — the primary desktop→phone handoff.
+ * The accessible label + the copyable link fallback are the §9 non-visual
+ * equivalents.
+ */
+export function ShareQr({ link }: { link: string }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [failed, setFailed] = useState(false);
+  const [size] = useState(() => Math.min(320, Math.floor(window.innerWidth * 0.8)));
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null) return;
+    let stale = false;
+    QRCode.toCanvas(canvas, link, { width: size, margin: 2, errorCorrectionLevel: 'M' }).catch(
+      () => {
+        if (!stale) setFailed(true);
+      },
+    );
+    return () => {
+      stale = true;
+    };
+  }, [link, size]);
+
+  if (failed) {
+    return (
+      <Typography.Text copyable style={{ wordBreak: 'break-all' }}>
+        {link}
+      </Typography.Text>
+    );
+  }
+  return (
+    <canvas
+      ref={canvasRef}
+      role="img"
+      aria-label="QR code of your FileKey share link"
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/web/src/share/a11y.test.tsx
+++ b/web/src/share/a11y.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App, ConfigProvider } from 'antd';
+import { appTheme } from '../theme';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+
+const sessionMock = {
+  locked: false,
+  unlock: vi.fn().mockResolvedValue(true),
+  lock: vi.fn(),
+  getSharePubHex: vi.fn().mockResolvedValue(VALID_HEX),
+};
+vi.mock('../state/session', () => ({ useSession: () => ({ ...sessionMock }) }));
+vi.mock('./ShareQr', () => ({ ShareQr: () => <div data-testid="qr" /> }));
+vi.mock('../files/db', () => ({ listRecipients: vi.fn().mockResolvedValue([]) }));
+vi.mock('./QrScanner', () => ({
+  hasCamera: vi.fn().mockResolvedValue(false),
+  QrScanner: () => null,
+}));
+// MyShareKeyButton → ShareCenter → RecipientsPane/inbound → validate → crypto/client
+// loads `new Worker(...)` at module scope; jsdom has no Worker. Mock the singleton.
+vi.mock('../crypto/client', () => ({ rpc: { call: vi.fn() } }));
+
+import { MyShareKeyButton } from './ShareCenter';
+
+function setDesktop() {
+  window.matchMedia = ((query: string) => ({
+    matches: /min-width/.test(query),
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+}
+
+async function renderOpenCenter() {
+  render(
+    <ConfigProvider theme={appTheme}>
+      <App>
+        <MyShareKeyButton />
+      </App>
+    </ConfigProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'My Share Key' }));
+  const dialog = await screen.findByRole('dialog');
+  await within(dialog).findByRole('button', { name: 'Copy link' });
+  return dialog;
+}
+
+beforeEach(() => {
+  setDesktop();
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+  delete (navigator as unknown as Record<string, unknown>).share;
+});
+
+describe('Share Center a11y (§9)', () => {
+  it('theme guarantees ≥44px large controls', () => {
+    expect(appTheme.token?.controlHeightLG).toBeGreaterThanOrEqual(44);
+  });
+
+  it('Share Center interactive controls all use the large (≥44px) size', async () => {
+    const dialog = await renderOpenCenter();
+    const buttons = within(dialog).getAllByRole('button');
+    // Scope to actual antd <Button> controls — the ones `controlHeightLG` governs.
+    // The modal's own Close affordance and the Collapse disclosure header ("Raw
+    // key") are not antd Buttons and carry no `size` prop to assert against.
+    const actionButtons = buttons.filter((b) => b.className.includes('ant-btn'));
+    expect(actionButtons.length).toBeGreaterThan(0);
+    for (const b of actionButtons) {
+      expect(b.className).toContain('ant-btn-lg');
+    }
+  });
+
+  it('Esc closes the Share Center (antd focus trap + Esc defaults)', async () => {
+    const dialog = await renderOpenCenter();
+    fireEvent.keyDown(dialog, { key: 'Escape', keyCode: 27 });
+    // jsdom fires no real CSS transitionend; nudge antd's exit motion to
+    // completion (once its listener attaches, a frame or two after Esc) so
+    // the unmount already triggered by Esc can be observed.
+    await waitFor(() => {
+      fireEvent.transitionEnd(dialog);
+      expect(screen.queryByRole('button', { name: 'Copy link' })).toBeNull();
+    });
+  });
+
+  it('traps focus inside the dialog (antd useLockFocus default)', async () => {
+    // jsdom does no layout, so every element reports `offsetParent: null` and a
+    // zero-size `getBoundingClientRect()`. antd's focus-lock (@rc-component/util
+    // `isVisible`) treats that as "not focusable", so the trap's redirect finds
+    // nothing to focus and silently no-ops. Stub `offsetParent` so the *real*
+    // production redirect logic actually runs, instead of asserting a markup
+    // detail (there is no sentinel element in this antd version — the trap is a
+    // window-level `focusin`/`keydown` listener, not DOM markup; see task report).
+    const offsetParentSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetParent', 'get')
+      .mockReturnValue(document.body);
+    try {
+      const dialog = await renderOpenCenter();
+      const outside = document.createElement('button');
+      outside.textContent = 'outside the dialog';
+      document.body.appendChild(outside);
+      try {
+        outside.focus();
+        await waitFor(() => expect(document.activeElement).not.toBe(outside));
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      } finally {
+        outside.remove();
+      }
+    } finally {
+      offsetParentSpy.mockRestore();
+    }
+  });
+});

--- a/web/src/share/inbound.test.tsx
+++ b/web/src/share/inbound.test.tsx
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App } from 'antd';
+import type { Recipient } from '../files/db';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66);
+
+const db = {
+  listRecipients: vi.fn<() => Promise<Recipient[]>>(),
+  addRecipient: vi.fn(),
+};
+vi.mock('../files/db', () => ({
+  listRecipients: () => db.listRecipients(),
+  addRecipient: (...a: unknown[]) => db.addRecipient(...a),
+}));
+
+const validateRecipientKey = vi.fn();
+vi.mock('./validate', () => ({
+  validateRecipientKey: (...a: unknown[]) => validateRecipientKey(...a),
+}));
+
+import { InboundShareBanner, resolveInboundShare } from './inbound';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.listRecipients.mockResolvedValue([]);
+  db.addRecipient.mockImplementation(async (name: string, pubHex: string) => ({
+    id: 'id-new',
+    name,
+    pubHex,
+    createdTs: 1,
+  }));
+  validateRecipientKey.mockResolvedValue(true);
+});
+
+describe('resolveInboundShare', () => {
+  it('returns null when there is no pub param', async () => {
+    expect(await resolveInboundShare('')).toBeNull();
+    expect(await resolveInboundShare('?theme=dark')).toBeNull();
+    expect(validateRecipientKey).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid for a malformed or off-curve key', async () => {
+    expect(await resolveInboundShare('?pub=04deadbeef')).toBe('invalid');
+    validateRecipientKey.mockResolvedValue(false);
+    expect(await resolveInboundShare(`?pub=${VALID_HEX}`)).toBe('invalid');
+  });
+
+  it('validates with no restore target (the inbound key IS the active key)', async () => {
+    await resolveInboundShare(`?pub=${VALID_HEX}`);
+    expect(validateRecipientKey).toHaveBeenCalledWith(VALID_HEX, null);
+  });
+
+  it('matches a saved recipient by pubHex and carries its name', async () => {
+    db.listRecipients.mockResolvedValue([
+      { id: 'id-1', name: 'Alice', pubHex: VALID_HEX, createdTs: 1 },
+    ]);
+    expect(await resolveInboundShare(`?pub=${VALID_HEX.toUpperCase()}`)).toEqual({
+      pubHex: VALID_HEX,
+      recipientName: 'Alice',
+    });
+  });
+
+  it('carries a null name for an unknown key', async () => {
+    expect(await resolveInboundShare(`?pub=${VALID_HEX}`)).toEqual({
+      pubHex: VALID_HEX,
+      recipientName: null,
+    });
+  });
+});
+
+describe('InboundShareBanner', () => {
+  it('shows the saved recipient name and no Save action when matched', () => {
+    render(
+      <App>
+        <InboundShareBanner
+          share={{ pubHex: VALID_HEX, recipientName: 'Alice' }}
+          onSaved={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      </App>,
+    );
+    expect(screen.getByText('Sharing to Alice')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save as recipient' })).toBeNull();
+  });
+
+  it('shows the truncated key and saves as a named recipient', async () => {
+    const onSaved = vi.fn();
+    render(
+      <App>
+        <InboundShareBanner
+          share={{ pubHex: VALID_HEX, recipientName: null }}
+          onSaved={onSaved}
+          onDismiss={vi.fn()}
+        />
+      </App>,
+    );
+    expect(screen.getByText('Sharing to 04a1…a1b2')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Save as recipient' }));
+    const modal = await screen.findByRole('dialog');
+    fireEvent.change(within(modal).getByRole('textbox', { name: 'Recipient name' }), {
+      target: { value: 'Alice' },
+    });
+    fireEvent.click(within(modal).getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(db.addRecipient).toHaveBeenCalledWith('Alice', VALID_HEX));
+    expect(onSaved).toHaveBeenCalledWith('Alice');
+  });
+
+  it('dismisses', () => {
+    const onDismiss = vi.fn();
+    render(
+      <App>
+        <InboundShareBanner
+          share={{ pubHex: VALID_HEX, recipientName: null }}
+          onSaved={vi.fn()}
+          onDismiss={onDismiss}
+        />
+      </App>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/share/inbound.tsx
+++ b/web/src/share/inbound.tsx
@@ -1,0 +1,93 @@
+import { createContext, useContext, useState } from 'react';
+import { Alert, Button, Input, Modal, Space } from 'antd';
+import { addRecipient, listRecipients } from '../files/db';
+import { parseShareInput, truncateKey } from './link';
+import { validateRecipientKey } from './validate';
+
+export type InboundShare = { pubHex: string; recipientName: string | null };
+
+/** Inbound ?pub= key, available to the Share Center (validation restore
+ *  target) and the per-file picker (default recipient) app-wide. */
+export const InboundShareContext = createContext<InboundShare | null>(null);
+
+export function useInboundShare(): InboundShare | null {
+  return useContext(InboundShareContext);
+}
+
+/**
+ * Resolves the ?pub= deep link on app load (legacy pre-attach semantics,
+ * design §14): validates and leaves the key set as the worker's shared pub.
+ * Returns null when no pub param, 'invalid' on parse/validation failure.
+ */
+export async function resolveInboundShare(
+  search: string,
+): Promise<InboundShare | 'invalid' | null> {
+  const pub = new URLSearchParams(search).get('pub');
+  if (pub === null) return null;
+  const pubHex = parseShareInput(pub);
+  if (pubHex === null) return 'invalid';
+  // activePubHex = null: the inbound key IS becoming the active key — no restore.
+  const ok = await validateRecipientKey(pubHex, null);
+  if (!ok) return 'invalid';
+  const recipients = await listRecipients();
+  const match = recipients.find((r) => r.pubHex === pubHex);
+  return { pubHex, recipientName: match?.name ?? null };
+}
+
+export function InboundShareBanner({
+  share,
+  onSaved,
+  onDismiss,
+}: {
+  share: InboundShare;
+  onSaved: (name: string) => void;
+  onDismiss: () => void;
+}) {
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [name, setName] = useState('');
+  const label = share.recipientName ?? truncateKey(share.pubHex);
+
+  const save = async () => {
+    const recipient = await addRecipient(name.trim(), share.pubHex);
+    setSaveOpen(false);
+    onSaved(recipient.name);
+  };
+
+  return (
+    <>
+      <Alert
+        type="info"
+        showIcon
+        message={`Sharing to ${label}`}
+        action={
+          <Space>
+            {share.recipientName === null && (
+              <Button size="small" type="primary" onClick={() => setSaveOpen(true)}>
+                Save as recipient
+              </Button>
+            )}
+            <Button size="small" onClick={onDismiss}>
+              Dismiss
+            </Button>
+          </Space>
+        }
+      />
+      <Modal
+        title="Save recipient"
+        open={saveOpen}
+        okText="Save"
+        okButtonProps={{ disabled: name.trim() === '' }}
+        onOk={save}
+        onCancel={() => setSaveOpen(false)}
+      >
+        <Input
+          size="large"
+          aria-label="Recipient name"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </Modal>
+    </>
+  );
+}

--- a/web/src/share/link.test.ts
+++ b/web/src/share/link.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { parseShareInput, RAW_KEY_RE, shareLink, truncateKey } from './link';
+
+const VALID_HEX = '04' + 'a1b2'.repeat(66); // 2 + 264 = 266 chars
+const VALID_UPPER = VALID_HEX.toUpperCase();
+
+describe('RAW_KEY_RE', () => {
+  it('matches a valid 266-hex share key', () => {
+    expect(RAW_KEY_RE.test(VALID_HEX)).toBe(true);
+  });
+  it('rejects a key not starting with 04', () => {
+    expect(RAW_KEY_RE.test('05' + 'a1b2'.repeat(66))).toBe(false);
+  });
+  it('rejects wrong lengths and non-hex', () => {
+    expect(RAW_KEY_RE.test(VALID_HEX.slice(0, 265))).toBe(false);
+    expect(RAW_KEY_RE.test(VALID_HEX + 'a')).toBe(false);
+    expect(RAW_KEY_RE.test('04' + 'zz'.repeat(132))).toBe(false);
+  });
+});
+
+describe('shareLink', () => {
+  it('builds the ?pub= deep link on the current origin', () => {
+    expect(shareLink(VALID_HEX)).toBe(`${location.origin}/?pub=${VALID_HEX}`);
+  });
+});
+
+describe('parseShareInput', () => {
+  it('accepts a raw valid key and normalizes to lowercase', () => {
+    expect(parseShareInput(VALID_HEX)).toBe(VALID_HEX);
+    expect(parseShareInput(VALID_UPPER)).toBe(VALID_HEX.toLowerCase());
+  });
+  it('trims surrounding whitespace', () => {
+    expect(parseShareInput(`  ${VALID_HEX}\n`)).toBe(VALID_HEX);
+  });
+  it('accepts a URL containing ?pub=<valid hex>', () => {
+    expect(parseShareInput(`https://filekey.example/?pub=${VALID_HEX}`)).toBe(VALID_HEX);
+    expect(parseShareInput(`https://filekey.example/?theme=dark&pub=${VALID_UPPER}`)).toBe(
+      VALID_HEX.toLowerCase(),
+    );
+  });
+  it('rejects a URL without pub or with an invalid pub', () => {
+    expect(parseShareInput('https://filekey.example/')).toBeNull();
+    expect(parseShareInput('https://filekey.example/?pub=04deadbeef')).toBeNull();
+  });
+  it('rejects garbage, empty, and near-miss keys', () => {
+    expect(parseShareInput('')).toBeNull();
+    expect(parseShareInput('not a key')).toBeNull();
+    expect(parseShareInput('05' + 'a1b2'.repeat(66))).toBeNull();
+  });
+});
+
+describe('truncateKey', () => {
+  it('formats first-4…last-4', () => {
+    expect(truncateKey(VALID_HEX)).toBe('04a1…a1b2');
+  });
+});

--- a/web/src/share/link.ts
+++ b/web/src/share/link.ts
@@ -1,0 +1,30 @@
+/** Single source of the Share-Key / deep-link contract (design D2, §14). */
+export const RAW_KEY_RE = /^04[0-9a-fA-F]{264}$/;
+
+/** The primary share artifact: the ?pub= deep link (D2). */
+export function shareLink(pubHex: string): string {
+  return `${location.origin}/?pub=${pubHex}`;
+}
+
+/** `04a1…9f2e` — first 4 + last 4 hex chars. */
+export function truncateKey(pubHex: string): string {
+  return `${pubHex.slice(0, 4)}…${pubHex.slice(-4)}`;
+}
+
+/**
+ * Accepts a raw 266-hex Share Key or any URL whose query contains a valid
+ * ?pub=. Returns normalized lowercase hex, or null if the input is neither.
+ */
+export function parseShareInput(input: string): string | null {
+  const trimmed = input.trim();
+  if (RAW_KEY_RE.test(trimmed)) return trimmed.toLowerCase();
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  const pub = url.searchParams.get('pub');
+  if (pub !== null && RAW_KEY_RE.test(pub)) return pub.toLowerCase();
+  return null;
+}

--- a/web/src/share/shareFile.test.ts
+++ b/web/src/share/shareFile.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { bufferToHex } from '../crypto/buffer';
+
+const call = vi.fn();
+vi.mock('../crypto/client', () => ({
+  rpc: { call: (...args: unknown[]) => call(...args) },
+}));
+
+import { encryptForRecipient, IV_LEN, SENDER_PUB_LEN, sharedFileName } from './shareFile';
+
+const RECIPIENT_HEX = '04' + 'a1b2'.repeat(66);
+const senderPub = new Uint8Array(133).fill(0x42);
+const iv = new Uint8Array(16).fill(0x07);
+const ct = new Uint8Array([9, 8, 7, 6]);
+
+beforeEach(() => {
+  call.mockReset();
+  call.mockImplementation(async (msgType: string) => {
+    if (msgType === 'set_shared_pub') return true;
+    if (msgType === 'get_det_public_ecdh') return senderPub.slice().buffer;
+    if (msgType === 'shared_ecdh_enc') {
+      return { encrypted_buff: ct.slice().buffer, salt: iv.slice().buffer };
+    }
+    throw new Error(`unexpected msg_type: ${msgType}`);
+  });
+});
+
+describe('encryptForRecipient', () => {
+  it('calls set_shared_pub, get_det_public_ecdh, shared_ecdh_enc in order', async () => {
+    const data = new Uint8Array([1, 2, 3]).buffer;
+    await encryptForRecipient(data, RECIPIENT_HEX);
+    expect(call.mock.calls.map((c) => c[0])).toEqual([
+      'set_shared_pub',
+      'get_det_public_ecdh',
+      'shared_ecdh_enc',
+    ]);
+    const setPubPayload = call.mock.calls[0][1] as { pub_buff: ArrayBuffer };
+    expect(bufferToHex(setPubPayload.pub_buff)).toBe(RECIPIENT_HEX.toLowerCase());
+  });
+
+  it('assembles senderPub(133) ‖ iv(16) ‖ ct (frozen format, design §14)', async () => {
+    const out = new Uint8Array(
+      await encryptForRecipient(new Uint8Array([1, 2, 3]).buffer, RECIPIENT_HEX),
+    );
+    expect(out.byteLength).toBe(SENDER_PUB_LEN + IV_LEN + ct.byteLength);
+    expect(Array.from(out.slice(0, SENDER_PUB_LEN))).toEqual(Array.from(senderPub));
+    expect(Array.from(out.slice(SENDER_PUB_LEN, SENDER_PUB_LEN + IV_LEN))).toEqual(
+      Array.from(iv),
+    );
+    expect(Array.from(out.slice(SENDER_PUB_LEN + IV_LEN))).toEqual(Array.from(ct));
+  });
+
+  it('does not consume the caller\'s data buffer (Save must keep working)', async () => {
+    const data = new Uint8Array([1, 2, 3]).buffer;
+    await encryptForRecipient(data, RECIPIENT_HEX);
+    expect(data.byteLength).toBe(3); // not detached by the transfer
+  });
+
+  it('rejects when the sender key is unavailable (locked worker)', async () => {
+    call.mockImplementation(async (msgType: string) =>
+      msgType === 'get_det_public_ecdh' ? null : true,
+    );
+    await expect(
+      encryptForRecipient(new Uint8Array([1]).buffer, RECIPIENT_HEX),
+    ).rejects.toThrow(/Share Key unavailable/);
+  });
+});
+
+describe('sharedFileName', () => {
+  it('uses outName when present, else name', () => {
+    expect(sharedFileName({ name: 'a.txt.filekey', outName: 'a.txt' })).toBe(
+      'a.txt.shared_filekey',
+    );
+    expect(sharedFileName({ name: 'photo.jpg' })).toBe('photo.jpg.shared_filekey');
+  });
+});
+
+describe('concurrency: withSharedPubLock serializes the shared-pub critical section', () => {
+  const RECIP_A = '04' + 'a1b2'.repeat(66);
+  const RECIP_B = '04' + 'c3d4'.repeat(66);
+
+  it('does not interleave two concurrent encrypts (never set→set→enc)', async () => {
+    // Make set_shared_pub yield (real await boundary) so an unlocked impl WOULD
+    // interleave; the lock must still keep each recipient's triple contiguous.
+    call.mockReset();
+    call.mockImplementation(async (msgType: string) => {
+      if (msgType === 'set_shared_pub') {
+        await Promise.resolve();
+        return true;
+      }
+      if (msgType === 'get_det_public_ecdh') return senderPub.slice().buffer;
+      if (msgType === 'shared_ecdh_enc') {
+        return { encrypted_buff: ct.slice().buffer, salt: iv.slice().buffer };
+      }
+      throw new Error(`unexpected msg_type: ${msgType}`);
+    });
+
+    await Promise.all([
+      encryptForRecipient(new Uint8Array([1]).buffer, RECIP_A),
+      encryptForRecipient(new Uint8Array([2]).buffer, RECIP_B),
+    ]);
+
+    const seq = call.mock.calls.map((c) => c[0]);
+    const oneTriple = ['set_shared_pub', 'get_det_public_ecdh', 'shared_ecdh_enc'];
+    // The recorded sequence must be one recipient's full triple followed by the
+    // other's — one of the two fully-grouped orderings, never an interleaving.
+    expect(seq).toEqual([...oneTriple, ...oneTriple]);
+    // And the first set_shared_pub's key must still own the first shared_ecdh_enc:
+    // no second set_shared_pub appears between index 0 (set) and index 2 (enc).
+    expect(seq.slice(0, 3)).toEqual(oneTriple);
+  });
+});

--- a/web/src/share/shareFile.ts
+++ b/web/src/share/shareFile.ts
@@ -1,0 +1,64 @@
+import { rpc } from '../crypto/client';
+import { hexToArrayBuffer } from '../crypto/buffer';
+import type { FileJob } from '../files/ops';
+import { withSharedPubLock } from './sharedPub';
+
+export const SENDER_PUB_LEN = 133;
+export const IV_LEN = 16; // the worker's shared_ecdh_enc reply names this `salt`
+
+/**
+ * Existing shared_ecdh_enc path (design §8.2). Invariant established here:
+ * set_shared_pub for the CHOSEN recipient always immediately precedes
+ * shared_ecdh_enc in the same flow — worker shared-pub state is never
+ * trusted across flows (see validate.ts for why that makes the validation
+ * dry-run safe). The whole set_shared_pub → get_det_public_ecdh →
+ * shared_ecdh_enc → assemble sequence runs inside `withSharedPubLock` so it is
+ * atomic against any concurrent flow (another encrypt, or a recipient
+ * validation dry-run) that also touches the worker's single shared-pub slot —
+ * without the lock, two flows could interleave set→set→enc and encrypt to the
+ * WRONG recipient. Output format is frozen: senderPub(133) ‖ iv(16) ‖ ct.
+ */
+export async function encryptForRecipient(
+  data: ArrayBuffer,
+  recipientPubHex: string,
+): Promise<ArrayBuffer> {
+  return withSharedPubLock(async () => {
+    const pubBuff = hexToArrayBuffer(recipientPubHex.toLowerCase());
+    await rpc.call<boolean>('set_shared_pub', { pub_buff: pubBuff }, [pubBuff]);
+
+    const senderPub = await rpc.call<ArrayBuffer | null>('get_det_public_ecdh');
+    if (senderPub === null || senderPub.byteLength !== SENDER_PUB_LEN) {
+      throw new Error('Share Key unavailable — unlock and try again');
+    }
+
+    // Copy before transfer: the job's cached bytes must survive for Save.
+    const msgBuff = data.slice(0);
+    const { encrypted_buff, salt } = await rpc.call<{
+      encrypted_buff: ArrayBuffer;
+      salt: ArrayBuffer;
+    }>('shared_ecdh_enc', { msg_buff: msgBuff }, [msgBuff]);
+    if (salt.byteLength !== IV_LEN) {
+      throw new Error(`unexpected IV length from worker: ${salt.byteLength}`);
+    }
+
+    const out = new Uint8Array(SENDER_PUB_LEN + IV_LEN + encrypted_buff.byteLength);
+    out.set(new Uint8Array(senderPub), 0);
+    out.set(new Uint8Array(salt), SENDER_PUB_LEN);
+    out.set(new Uint8Array(encrypted_buff), SENDER_PUB_LEN + IV_LEN);
+    return out.buffer;
+  });
+}
+
+export function sharedFileName(job: Pick<FileJob, 'name' | 'outName'>): string {
+  return `${job.outName ?? job.name}.shared_filekey`;
+}
+
+/** <a download> save — always available on desktop (design §8.2). */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/web/src/share/shareFile.ts
+++ b/web/src/share/shareFile.ts
@@ -52,13 +52,3 @@ export async function encryptForRecipient(
 export function sharedFileName(job: Pick<FileJob, 'name' | 'outName'>): string {
   return `${job.outName ?? job.name}.shared_filekey`;
 }
-
-/** <a download> save — always available on desktop (design §8.2). */
-export function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}

--- a/web/src/share/sharedPub.test.ts
+++ b/web/src/share/sharedPub.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { withSharedPubLock } from './sharedPub';
+
+/** A manually-resolvable promise — the only synchronization primitive these
+ *  tests use, so ordering is deterministic (no real timers, no randomness). */
+function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('withSharedPubLock', () => {
+  it('serializes criticals: the second does not start until the first settles', async () => {
+    const order: string[] = [];
+    const gate1 = deferred();
+
+    let secondStarted = false;
+
+    const first = withSharedPubLock(async () => {
+      order.push('start1');
+      await gate1.promise; // hold the lock until we release it
+      order.push('finish1');
+    });
+
+    const second = withSharedPubLock(async () => {
+      secondStarted = true;
+      order.push('start2');
+      order.push('finish2');
+    });
+
+    // Let all currently-schedulable microtasks drain. The first critical is
+    // parked on gate1; the second must NOT have started yet.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondStarted).toBe(false);
+    expect(order).toEqual(['start1']);
+
+    // Release the first critical; only now may the second run.
+    gate1.resolve();
+    await Promise.all([first, second]);
+
+    expect(secondStarted).toBe(true);
+    // Strictly non-interleaved: first fully finishes before second starts.
+    expect(order).toEqual(['start1', 'finish1', 'start2', 'finish2']);
+  });
+
+  it('a rejected critical does not wedge the lock for later callers', async () => {
+    const boom = new Error('critical A failed');
+
+    const a = withSharedPubLock(async () => {
+      throw boom;
+    });
+
+    let bRan = false;
+    const b = withSharedPubLock(async () => {
+      bRan = true;
+      return 'B ok';
+    });
+
+    await expect(a).rejects.toBe(boom); // caller can catch A's rejection
+    await expect(b).resolves.toBe('B ok'); // B still runs afterward
+    expect(bRan).toBe(true);
+  });
+
+  it('passes the critical section return value through', async () => {
+    await expect(withSharedPubLock(() => Promise.resolve(42))).resolves.toBe(42);
+  });
+});

--- a/web/src/share/sharedPub.ts
+++ b/web/src/share/sharedPub.ts
@@ -1,0 +1,14 @@
+// Serializes every set_shared_pub → (shared_ecdh_enc | dry-run) critical section
+// against the worker's single module-global shared_ecdh_pub_key slot. The worker
+// (frozen, design §14) does not serialize message handling and set_shared_pub has
+// an internal await before it writes the slot, so two concurrent flows (a recipient
+// validation dry-run and a per-file encrypt, or two encrypts) could otherwise
+// interleave set→set→enc and encrypt to the WRONG recipient. validate.ts and
+// shareFile.ts both run their slot-touching sequence through this lock, making
+// set-then-use atomic from the worker's perspective.
+let chain: Promise<unknown> = Promise.resolve();
+export function withSharedPubLock<T>(critical: () => Promise<T>): Promise<T> {
+  const run = chain.then(critical, critical);
+  chain = run.then(() => undefined, () => undefined);
+  return run;
+}

--- a/web/src/share/validate.test.ts
+++ b/web/src/share/validate.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { bufferToHex } from '../crypto/buffer';
+
+const call = vi.fn();
+vi.mock('../crypto/client', () => ({
+  rpc: { call: (...args: unknown[]) => call(...args) },
+}));
+
+import { validateRecipientKey } from './validate';
+
+const CANDIDATE = '04' + 'a1b2'.repeat(66);
+const ACTIVE = '04' + 'c3d4'.repeat(66);
+
+beforeEach(() => {
+  call.mockReset();
+  call.mockResolvedValue(true);
+});
+
+describe('validateRecipientKey', () => {
+  it('rejects on regex fast path without touching the worker', async () => {
+    expect(await validateRecipientKey('garbage', null)).toBe(false);
+    expect(await validateRecipientKey('05' + 'a1b2'.repeat(66), null)).toBe(false);
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('dry-runs set_shared_pub with the 133-byte key buffer, transferred', async () => {
+    expect(await validateRecipientKey(CANDIDATE, null)).toBe(true);
+    expect(call).toHaveBeenCalledTimes(1);
+    const [msgType, payload, transfer] = call.mock.calls[0] as [
+      string,
+      { pub_buff: ArrayBuffer },
+      Transferable[],
+    ];
+    expect(msgType).toBe('set_shared_pub');
+    expect(payload.pub_buff.byteLength).toBe(133);
+    expect(bufferToHex(payload.pub_buff)).toBe(CANDIDATE.toLowerCase());
+    expect(transfer).toEqual([payload.pub_buff]);
+  });
+
+  it('returns false when the worker rejects (off-curve point)', async () => {
+    call.mockRejectedValueOnce(new Error('importKey failed'));
+    expect(await validateRecipientKey(CANDIDATE, null)).toBe(false);
+  });
+
+  it('re-sets the active recipient after validating a different candidate', async () => {
+    expect(await validateRecipientKey(CANDIDATE, ACTIVE)).toBe(true);
+    expect(call).toHaveBeenCalledTimes(2);
+    const [, restorePayload] = call.mock.calls[1] as [string, { pub_buff: ArrayBuffer }];
+    expect(call.mock.calls[1][0]).toBe('set_shared_pub');
+    expect(bufferToHex(restorePayload.pub_buff)).toBe(ACTIVE.toLowerCase());
+  });
+
+  it('re-sets the active recipient even when the candidate was invalid', async () => {
+    call.mockRejectedValueOnce(new Error('importKey failed'));
+    expect(await validateRecipientKey(CANDIDATE, ACTIVE)).toBe(false);
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call.mock.calls[1][0]).toBe('set_shared_pub');
+  });
+
+  it('does not re-set when the candidate IS the active recipient (case-insensitive)', async () => {
+    expect(await validateRecipientKey(CANDIDATE, CANDIDATE.toUpperCase())).toBe(true);
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-set when there is no active recipient', async () => {
+    expect(await validateRecipientKey(CANDIDATE, null)).toBe(true);
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/share/validate.ts
+++ b/web/src/share/validate.ts
@@ -1,0 +1,57 @@
+import { rpc } from '../crypto/client';
+import { hexToArrayBuffer } from '../crypto/buffer';
+import { RAW_KEY_RE } from './link';
+import { withSharedPubLock } from './sharedPub';
+
+/**
+ * Validates a candidate Share Key: regex fast path, then a `set_shared_pub`
+ * dry-run — the worker's `importEcdhPub` (SubtleCrypto `importKey`) rejects
+ * off-curve points, which the regex cannot catch.
+ *
+ * WHY NO NEW msg_type (`validate_pub`): the Phase 1 worker protocol is frozen,
+ * and a dedicated validation message would duplicate the exact same importKey
+ * knowledge `set_shared_pub` already owns. The dry-run's only side effect is
+ * that the worker's shared-pub slot now holds the candidate. That is safe
+ * because of two things this phase establishes: (1) every `shared_ecdh_enc`
+ * caller re-sets `set_shared_pub` for its chosen recipient immediately
+ * beforehand within the same flow (see shareFile.ts), so worker shared-pub
+ * state is never trusted across flows; and (2) ALL shared-pub slot access —
+ * this dry-run and every real encrypt — is serialized through
+ * `withSharedPubLock`, so a set-then-use sequence is atomic from the worker's
+ * perspective and two concurrent flows cannot interleave set→set→enc (which
+ * would otherwise encrypt to the WRONG recipient — `set_shared_pub` awaits
+ * `importEcdhPub` before it writes the slot, and the frozen worker does not
+ * serialize message handling). The restore below is now a redundant best-effort
+ * courtesy for the one long-lived attachment we keep — the inbound `?pub=`
+ * deep-link key (legacy pre-attach semantics, design §14) — and may be dropped
+ * in a later cleanup; a failed restore is swallowed.
+ *
+ * The regex fast path returns false BEFORE acquiring the lock (no slot access,
+ * no reason to serialize).
+ */
+export async function validateRecipientKey(
+  pubHex: string,
+  activePubHex: string | null,
+): Promise<boolean> {
+  if (!RAW_KEY_RE.test(pubHex)) return false;
+
+  return withSharedPubLock(async () => {
+    let valid: boolean;
+    try {
+      const candidate = hexToArrayBuffer(pubHex.toLowerCase());
+      await rpc.call<boolean>('set_shared_pub', { pub_buff: candidate }, [candidate]);
+      valid = true;
+    } catch {
+      valid = false;
+    }
+
+    if (activePubHex !== null && activePubHex.toLowerCase() !== pubHex.toLowerCase()) {
+      const active = hexToArrayBuffer(activePubHex.toLowerCase());
+      await rpc
+        .call<boolean>('set_shared_pub', { pub_buff: active }, [active])
+        .catch(() => undefined);
+    }
+
+    return valid;
+  });
+}

--- a/web/src/theme.test.tsx
+++ b/web/src/theme.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ThemeProvider, useTheme } from './theme';
+import { appTheme, ThemeProvider, useTheme } from './theme';
 
 function Probe() {
   const { mode, toggle } = useTheme();
@@ -10,6 +10,12 @@ function Probe() {
     </button>
   );
 }
+
+describe('appTheme', () => {
+  it('sets controlHeightLG to 44 for the design §6/§9 ≥44px touch-target budget', () => {
+    expect(appTheme.token?.controlHeightLG).toBe(44);
+  });
+});
 
 describe('ThemeProvider', () => {
   beforeEach(() => {

--- a/web/src/theme.tsx
+++ b/web/src/theme.tsx
@@ -19,7 +19,10 @@ const STORAGE_KEY = 'fk_theme'; // parity with the old app's persistence key
 // (e.g. controlHeightLG). Keep the token minimal — colorPrimary is the only brand
 // override (design §4).
 export const appTheme: ThemeConfig = {
-  token: { colorPrimary: BRAND_PRIMARY },
+  token: {
+    colorPrimary: BRAND_PRIMARY,
+    controlHeightLG: 44, // ≥44px touch targets (design §6/§9)
+  },
   algorithm: antdTheme.defaultAlgorithm,
 };
 

--- a/web/src/ui/AppHeader.test.tsx
+++ b/web/src/ui/AppHeader.test.tsx
@@ -3,6 +3,19 @@ import { describe, expect, it, vi } from 'vitest';
 import { AppHeader } from './AppHeader';
 import { ThemeProvider } from '../theme';
 
+// AppHeader now renders <MyShareKeyButton /> (../share/ShareCenter), which pulls in
+// ../state/session → ../crypto/client, whose module scope does `new Worker(...)`;
+// jsdom has no Worker. Mock the session hook so AppHeader's own tests stay focused
+// on header chrome — Share Center behavior is covered by ShareCenter.test.tsx.
+vi.mock('../state/session', () => ({
+  useSession: () => ({
+    locked: false,
+    unlock: vi.fn().mockResolvedValue(true),
+    lock: vi.fn(),
+    getSharePubHex: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
 function renderHeader(over: Partial<Parameters<typeof AppHeader>[0]> = {}) {
   const props = {
     locked: true,

--- a/web/src/ui/AppHeader.test.tsx
+++ b/web/src/ui/AppHeader.test.tsx
@@ -15,6 +15,10 @@ vi.mock('../state/session', () => ({
     getSharePubHex: vi.fn().mockResolvedValue(null),
   }),
 }));
+// (Task 8) ShareCenter → RecipientsPane → ./validate also pulls in ../crypto/client
+// directly (not just via session), so the session mock above no longer shields this
+// suite from the module-scope `new Worker(...)`. Mock the singleton too.
+vi.mock('../crypto/client', () => ({ rpc: { call: vi.fn() } }));
 
 function renderHeader(over: Partial<Parameters<typeof AppHeader>[0]> = {}) {
   const props = {

--- a/web/src/ui/AppHeader.tsx
+++ b/web/src/ui/AppHeader.tsx
@@ -2,6 +2,7 @@ import { LockOutlined, MenuOutlined, MoonOutlined, SunOutlined } from '@ant-desi
 import { Button, Drawer, Dropdown, Grid, Menu, Space, Tag, Typography } from 'antd';
 import { useState } from 'react';
 import { useTheme } from '../theme';
+import { MyShareKeyButton } from '../share/ShareCenter';
 import type { DocKey } from './content';
 
 export type AppHeaderProps = {
@@ -73,6 +74,7 @@ export function AppHeader({ locked, onLock, onReset, onOpenDoc, version }: AppHe
           Lock
         </Button>
       )}
+      <MyShareKeyButton />
       <Button
         type="text"
         aria-label="Toggle dark mode"

--- a/web/src/ui/FileList.test.tsx
+++ b/web/src/ui/FileList.test.tsx
@@ -9,6 +9,13 @@ import * as save from '../files/save';
 // files/ops.test.ts already does, since this suite only exercises label rendering.
 vi.mock('../crypto/client', () => ({ rpc: { call: vi.fn() } }));
 
+// FileList now renders ShareFileAction (T10) per done row; useSession() throws
+// outside a <SessionProvider>, so mock it like ShareFileAction.test.tsx does —
+// this suite only asserts the per-row Share control is present, not its flow.
+vi.mock('../state/session', () => ({
+  useSession: () => ({ locked: false, unlock: vi.fn(), lock: vi.fn(), getSharePubHex: vi.fn() }),
+}));
+
 const done = (id: string, over: Partial<FileJob> = {}): FileJob => ({
   id,
   name: 'a.png',
@@ -72,5 +79,22 @@ describe('FileList', () => {
   it('renders nothing for an empty job list', () => {
     const { container } = render(<FileList jobs={[]} />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders Share as a sibling child of Save per row, not a List.Item actions array (B2)', () => {
+    render(<FileList jobs={[done('1'), done('2')]} />);
+    const items = screen.getAllByRole('listitem');
+    // Exactly one <li> per job — an `actions` array would add an extra <li> per action.
+    expect(items).toHaveLength(2);
+    for (const item of items) {
+      expect(within(item).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+      expect(within(item).getByRole('button', { name: /^save$/i })).toBeInTheDocument();
+    }
+  });
+
+  it('omits Share when the job has no cached data (job.data === undefined)', () => {
+    render(<FileList jobs={[done('1', { data: undefined })]} />);
+    const item = screen.getByRole('listitem');
+    expect(within(item).queryByRole('button', { name: 'Share' })).toBeNull();
   });
 });

--- a/web/src/ui/FileList.tsx
+++ b/web/src/ui/FileList.tsx
@@ -1,6 +1,7 @@
 import { Button, List, Spin, Tag, Typography } from 'antd';
 import { jobStatusLabel, type FileJob } from '../files/ops';
 import { saveJob } from '../files/save';
+import { ShareFileAction } from '../share/ShareFileAction';
 
 const NEXT_STEP: Record<string, string> = {
   'wrong passkey/key': 'Check you authenticated with the passkey this file was encrypted for.',
@@ -57,6 +58,9 @@ export function FileList({ jobs }: { jobs: FileJob[] }) {
                 ) : undefined
               }
             />
+            {job.status === 'done' && job.data !== undefined && (
+              <ShareFileAction key="share" job={job} />
+            )}
             {job.status === 'done' && (
               <Button type="primary" size="small" onClick={() => saveJob(job)}>
                 Save

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -47,6 +47,17 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
   });
 }
 
+// jsdom has no ResizeObserver; antd's rc-trigger (Popconfirm/Popover/Tooltip/Select)
+// observes trigger elements for positioning. First hit by RecipientsPane's Popconfirm.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class NoopResizeObserver implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = NoopResizeObserver;
+}
+
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
 afterEach(cleanup);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
         ],
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
+        globPatterns: ['**/*.{js,css,html,svg,png,webmanifest,wasm}'],
         cleanupOutdatedCaches: true,
         clientsClaim: true,
         skipWaiting: false, // prompt-driven update: SW skips waiting only on user Reload


### PR DESCRIPTION
## Phase 4 — Share Center + per-file share/save/export (final phase of the antd conversion)

Delivers design **§§7–9** in full: the Share Center (My Key + Recipients), per-file sharing to a recipient, the inbound `?pub=` banner, camera QR scan-in, and the §9 error/a11y behaviors — all offline, all TDD. This is the last phase; after merge the React 18 + Ant Design v6 + Vite conversion is complete.

### What's in it (11 tasks + 1 review-fix, one commit each)
- **Server** — `Permissions-Policy: camera=(self)` (the only Go change) so the QR scanner can request the same-origin camera.
- **`link.ts`** — single source of the Share-Key / deep-link contract (`^04[0-9a-fA-F]{264}$`, build/parse `?pub=`, truncation).
- **Recipients store** — IndexedDB v2→v3 (monotonic, keeps the `jobs` store), CRUD, wired into Reset (Reset wipes recipients; Lock keeps them).
- **`validate.ts` + `sharedPub.ts`** — recipient-key validation via a `set_shared_pub` worker **dry-run** (no new msg_type), serialized by a shared-pub **mutex** (see Security below).
- **`ShareQr.tsx`** — offline QR of the deep link (`qrcode`, no CDN).
- **`QrScanner.tsx` + `hasCamera`** — capability-detected scan-in: native `BarcodeDetector`, lazy `zxing-wasm` fallback with a self-hosted `.wasm` (precached for offline scan). No UA sniffing.
- **Share Center shell + My Key pane** — responsive Drawer (mobile) / Modal (desktop), lock-gated.
- **Recipients pane** — list / add (validated paste) / rename / delete / scan-in.
- **Inbound `?pub=` banner** — "Sharing to …" with save-as-recipient; replaces Phase 2's minimal parity notice and removes the last direct `set_shared_pub` caller from `App.tsx`.
- **Per-file share** — `Share` on a done file → recipient picker → `.shared_filekey` (`senderPub(133) ‖ iv(16) ‖ ct`) → Web Share (`canShare`-gated) / Save.
- **A11y sweep** — design §9 assertions + a 44px touch-target token.

### Security — the notable fix
The frozen worker's `shared_ecdh_enc` reads a module-global recipient slot set by a **separate** `set_shared_pub` call, and the worker doesn't serialize messages. Two concurrent flows (a validation dry-run + a per-file encrypt, or overlapping shares) could interleave `set→set→enc` and **silently encrypt a file to the wrong recipient**. Fixed client-side with a single promise-chain mutex (`withSharedPubLock`) that both `validate.ts` and `shareFile.ts` route their set→use sequence through — no change to the frozen worker. Verified by a non-interleave concurrency test and by the whole-branch review.

### Frozen invariants preserved
No changes to `web/src/crypto/**` or the worker; **no new worker msg_type**; `.shared_filekey` / Share-Key / `?pub=` formats unchanged. The golden-file harness stays green, and the new encrypt-assembly was checked byte-for-byte against the golden-fixture generator.

### Verification
- `web`: **205/205** tests (39 files, incl. golden harness), dual `tsc` clean.
- `npm run build` OK; `npm run test:dist` **9/9**; built `sw.js` precaches the zxing `.wasm` (offline scan works).
- `server`: `gofmt`/`go vet` clean, **29/29** tests (with the built bundle staged).
- Capability detection only (`grep userAgent web/src` empty); no CDN / runtime third-party fetch.

### Review process
Executed via subagent-driven development: SGE plan-review (12 folds applied) → per-task TDD with a per-task reviewer (caught + fixed real issues: an IndexedDB connection leak, a missing mutex-serialization test, a runaway scan-timer leak) → independent **whole-branch review** (0 Critical/Important; one pre-merge cleanup folded: consolidated the two `<a download>` helpers into one sanitizing path + hardened two `unlock()` error paths).

### Manual testing still owed (not automatable here)
On real **iOS + Android** against a deployed HTTPS instance: camera QR **scan-in** (native BarcodeDetector + the zxing-wasm fallback), the **Web Share** sheet (share vs. save, silent dismissal), offline scan after install, and the responsive Drawer/Modal + ≥44px touch targets.

> Note: commits on this branch are **unsigned** — the local 1Password SSH agent was unresponsive during this session (it also blocked signed commits on Phase 4's earlier tasks and SSH push, so the branch was pushed via the `gh` HTTPS token). Re-sign with a rebase if signatures are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
